### PR TITLE
Correctly identify newer versions of pi-topOS

### DIFF
--- a/i2samp.sh
+++ b/i2samp.sh
@@ -191,7 +191,7 @@ os_check() {
             fi
         done
     fi
-    if [ -f ~/.pt-dashboard-config ] || [ -d ~/.pt-dashboard ]; then
+    if [ -f ~/.pt-dashboard-config ] || [ -d ~/.pt-dashboard ] || [ -d ~/.pt-os-dashboard ]; then
         IS_RASPBIAN=false
         for os in ${oswarning[@]}; do
             if [ $os == "PiTop" ]; then


### PR DESCRIPTION
Makes use of `pt-os-dashboard` directory, rather than `pt-dashboard` from older versions.