### PR TITLE
added missing warning function to adafruit-pitft.sh

### DIFF
--- a/adafruit-pitft.sh
+++ b/adafruit-pitft.sh
@@ -47,6 +47,10 @@ TRANSFORM_28c180="1 0 0 0 1 0 0 0 1"
 TRANSFORM_28c270="0 -1 1 1 0 0 0 0 1"
 
 
+warning() { 
+	echo WARNING : $1
+}
+
 ############################ Script assisters ############################
 
 # Given a list of strings representing options, display each option


### PR DESCRIPTION
Hello,

I just tried adafruit-pitft.sh script and it seems "warning" function is missing : 
```
[PITFT] System update
Checking for correct software repositories...
./adafruit-pitft.sh: line 160: warning: command not found**
Updating apt indexes...
.........
```
The script is continuing instead of stopping because of this (although the script terminates with no other errors and the very nice 2.8" tft seems to work anyway).

Took  me a little way to understand that this was not a warning because of an unexisting command rather than an error because "warning" was a non existing command ;-) 

I created a (very) simple warning function.

Not sure if this is the way to contribute... but here is a PR.

JS