### PR TITLE
Keep cron & install ntp

### DIFF
--- a/read-only-fs.sh
+++ b/read-only-fs.sh
@@ -178,17 +178,17 @@ echo "Updating package index files..."
 apt-get update
 
 echo "Removing unwanted packages..."
-#apt-get remove -y --force-yes --purge triggerhappy cron logrotate dbus \
+#apt-get remove -y --force-yes --purge triggerhappy logrotate dbus \
 # dphys-swapfile xserver-common lightdm fake-hwclock
 # Let's keep dbus...that includes avahi-daemon, a la 'raspberrypi.local',
 # also keeping xserver & lightdm for GUI login (WIP, not working yet)
-apt-get remove -y --force-yes --purge triggerhappy cron logrotate \
+apt-get remove -y --force-yes --purge triggerhappy logrotate \
  dphys-swapfile fake-hwclock
 apt-get -y --force-yes autoremove --purge
 
 # Replace log management with busybox (use logread if needed)
-echo "Installing busybox-syslogd..."
-apt-get -y --force-yes install busybox-syslogd; dpkg --purge rsyslog
+echo "Installing ntp and busybox-syslogd..."
+apt-get -y --force-yes install ntp busybox-syslogd; dpkg --purge rsyslog
 
 echo "Configuring system..."
 


### PR DESCRIPTION
Keep cron so time tasks are still possible. If there's no internet connection, of course only interval will be correct, but not the execution time.
If there's an internet connection, ntp will set the time after boot, and then even the execution time will be right.