### PR TITLE
pitft: add ExecStartPre sleep of 10 seconds before starting fbcp

### DIFF
--- a/adafruit-pitft.sh
+++ b/adafruit-pitft.sh
@@ -400,6 +400,7 @@ After=network.target
 
 [Service]
 Type=simple
+ExecStartPre=/bin/sleep 10
 ExecStart=/usr/local/bin/fbcp
 
 [Install]


### PR DESCRIPTION
Hopefully fixes glitchiness described in [this forum thread](https://forums.adafruit.com/viewtopic.php?f=47&t=142746&p=707588).

Tested on Pi 1; appears to be working.