### PR TITLE
aplay: change rate to 44100 to avoid unnecessary CPU usage

### DIFF
--- a/i2samp.sh
+++ b/i2samp.sh
@@ -445,7 +445,7 @@ EOL
 Description=Invoke aplay from /dev/zero at system start.
 
 [Service]
-ExecStart=/usr/bin/aplay -D default -t raw -r 48000 -c 2 -f S16_LE /dev/zero
+ExecStart=/usr/bin/aplay -D default -t raw -r 44100 -c 2 -f S16_LE /dev/zero
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The aplay service plays `/dev/zero` to avoid clicks. The current version uses a sampling rate of 48 kHz, while ALSA is configured to use 44.1 kHz  (some lines above in `i2samp.sh`).
This leads to ALSA/dmixer resampling the silence to the right rate, which is unnecessary. CPU usage is much better if the sampling rate is set correctly in aplay (tested on a Raspberry Pi 3).