### PR TITLE
libgpiod.sh doesn't assume Python 3.5 anymore

### DIFF
--- a/libgpiod.sh
+++ b/libgpiod.sh
@@ -47,8 +47,8 @@ export PYTHON_VERSION=3
    && sudo ldconfig
 
 # This is not the right way to do this:
-sudo cp bindings/python/.libs/gpiod.so /usr/local/lib/python3.5/dist-packages/
-sudo cp bindings/python/.libs/gpiod.la /usr/local/lib/python3.5/dist-packages/
-sudo cp bindings/python/.libs/gpiod.a /usr/local/lib/python3.5/dist-packages/
+sudo cp bindings/python/.libs/gpiod.so /usr/local/lib/python3.?/dist-packages/
+sudo cp bindings/python/.libs/gpiod.la /usr/local/lib/python3.?/dist-packages/
+sudo cp bindings/python/.libs/gpiod.a /usr/local/lib/python3.?/dist-packages/
 
 exit 0


### PR DESCRIPTION
Fixes #53. Needed for guide since DragonBoard 410c runs Python 3.7.