### PR TITLE
Fixes PiTFT Installer for Buster

### DIFF
--- a/adafruit-pitft.sh
+++ b/adafruit-pitft.sh
@@ -190,7 +190,7 @@ reconfig() {
 
 function softwareinstall() {
     echo "Installing Pre-requisite Software...This may take a few minutes!"
-		apt-get install -y tslib 1> /dev/null 2>&1 || apt-get install -y libts0 1> /dev/null 2>&1 || { warning "Apt failed to install TSLIB!" && exit 1; }
+		apt-get install -y libts0 1> /dev/null 2>&1 || apt-get install -y tslib 1> /dev/null 2>&1 || { warning "Apt failed to install TSLIB!" && exit 1; }
     apt-get install -y bc fbi git python-dev python-pip python-smbus python-spidev evtest libts-bin 1> /dev/null  || { warning "Apt failed to install software!" && exit 1; }
     pip install evdev 1> /dev/null  || { warning "Pip failed to install software!" && exit 1; }
 }

--- a/adafruit-pitft.sh
+++ b/adafruit-pitft.sh
@@ -48,7 +48,7 @@ TRANSFORM_28c180="1 0 0 0 1 0 0 0 1"
 TRANSFORM_28c270="0 -1 1 1 0 0 0 0 1"
 
 
-warning() { 
+warning() {
 	echo WARNING : $1
 }
 
@@ -190,7 +190,8 @@ reconfig() {
 
 function softwareinstall() {
     echo "Installing Pre-requisite Software...This may take a few minutes!"
-    apt-get install -y bc fbi git python-dev python-pip python-smbus python-spidev evtest tslib libts-bin 1> /dev/null  || { warning "Apt failed to install software!" && exit 1; }
+		apt-get install -y tslib 1> /dev/null 2>&1 || apt-get install -y libts0 1> /dev/null 2>&1 || { warning "Apt failed to install TSLIB!" && exit 1; }
+    apt-get install -y bc fbi git python-dev python-pip python-smbus python-spidev evtest libts-bin 1> /dev/null  || { warning "Apt failed to install software!" && exit 1; }
     pip install evdev 1> /dev/null  || { warning "Pip failed to install software!" && exit 1; }
 }
 


### PR DESCRIPTION
This change attempts to install libts0 for Buster and if that fails, it tries tslib for older versions of Raspbian.
Fixes #46. Fixes #55.