### PR TITLE
Update library reference to support Pi 4

### DIFF
--- a/rgb-matrix.sh
+++ b/rgb-matrix.sh
@@ -7,7 +7,7 @@
 # we reference a specific commit (update this as needed):
 GITUSER=https://github.com/hzeller
 REPO=rpi-rgb-led-matrix
-COMMIT=814b79b5696d32dd1140304b41a1ec0068bb271a
+COMMIT=5549b6a8539f6191b0042a9882844a36716acebd
 
 if [ $(id -u) -ne 0 ]; then
 	echo "Installer must be run as root."

--- a/rgb-matrix.sh
+++ b/rgb-matrix.sh
@@ -7,7 +7,7 @@
 # we reference a specific commit (update this as needed):
 GITUSER=https://github.com/hzeller
 REPO=rpi-rgb-led-matrix
-COMMIT=5549b6a8539f6191b0042a9882844a36716acebd
+COMMIT=e3dd56dcc0408862f39cccc47c1d9dea1b0fb2d2 
 
 if [ $(id -u) -ne 0 ]; then
 	echo "Installer must be run as root."


### PR DESCRIPTION
The existing commit reference for hzeller's library points to a version of which doesn't support the recently released Raspberry Pi 4. Edited the script to point to the new commit before running it and it started working fine on the Pi4.