### PR TITLE
replace deprecated --force-yes

### DIFF
--- a/adafruit-pitft.sh
+++ b/adafruit-pitft.sh
@@ -345,7 +345,7 @@ function uninstall_console() {
 
 function install_fbcp() {
     echo "Installing cmake..."
-    apt-get --yes --force-yes install cmake 1> /dev/null  || { warning "Apt failed to install software!" && exit 1; }
+    apt-get --yes --allow-downgrades --allow-remove-essential --allow-change-held-packages install cmake 1> /dev/null  || { warning "Apt failed to install software!" && exit 1; }
     echo "Downloading rpi-fbcp..."
     cd /tmp
     #curl -sLO https://github.com/tasanakorn/rpi-fbcp/archive/master.zip


### PR DESCRIPTION
See [https://manpages.debian.org/stretch/apt/apt-get.8.en.html](https://manpages.debian.org/stretch/apt/apt-get.8.en.html)

**--force-yes**
Force yes; this is a dangerous option that will cause apt to continue without prompting if it is doing something potentially harmful. It should not be used except in very special situations. Using force-yes can potentially destroy your system! Configuration Item: APT::Get::force-yes. This is deprecated and replaced by --allow-downgrades, --allow-remove-essential, --allow-change-held-packages in 1.1.