### PR TITLE
Update udev rule for cap touch

### DIFF
--- a/adafruit-pitft.sh
+++ b/adafruit-pitft.sh
@@ -283,6 +283,7 @@ SUBSYSTEM=="input", ATTRS{name}=="touchmouse", ENV{DEVNAME}=="*event*", SYMLINK+
 EOF
     cat > /etc/udev/rules.d/95-ftcaptouch.rules <<EOF
 SUBSYSTEM=="input", ATTRS{name}=="EP0110M09", ENV{DEVNAME}=="*event*", SYMLINK+="input/touchscreen"
+SUBSYSTEM=="input", ATTRS{name}=="generic ft5x06*", ENV{DEVNAME}=="*event*", SYMLINK+="input/touchscreen"
 EOF
     cat > /etc/udev/rules.d/95-stmpe.rules <<EOF
 SUBSYSTEM=="input", ATTRS{name}=="*stmpe*", ENV{DEVNAME}=="*event*", SYMLINK+="input/touchscreen"


### PR DESCRIPTION
For #83 

Simply adding a second line to match latest pattern and leave existing line for back compat. Tested as far as confirming that a `touchscreen` symlink is created:
```console
pi@raspberrypi:~ $ ls /dev/input
by-path  event0  mice  mouse0  touchscreen
```

**Additional info FWIW**
Obtained with `2020-02-13 Raspbian Lite` on a Pi 3.
```console
pi@raspberrypi:~ $ dmesg | grep input
[    7.519706] input: generic ft5x06 (11) as /devices/platform/soc/3f804000.i2c/i2c-1/1-0038/input/input0
pi@raspberrypi:~ $ udevadm info --attribute-walk --path=/devices/platform/soc/3f804000.i2c/i2c-1/1-0038/input/input0

Udevadm info starts with the device specified by the devpath and then
walks up the chain of parent devices. It prints for every device
found, all possible attributes in the udev rules key format.
A rule to match, can be composed by the attributes of the device
and the attributes from one single parent device.

  looking at device '//devices/platform/soc/3f804000.i2c/i2c-1/1-0038/input/input0':
    KERNEL=="input0"
    SUBSYSTEM=="input"
    DRIVER==""
    ATTR{uniq}==""
    ATTR{phys}==""
    ATTR{properties}=="2"
    ATTR{name}=="generic ft5x06 (11)"

  looking at parent device '//devices/platform/soc/3f804000.i2c/i2c-1/1-0038':
    KERNELS=="1-0038"
    SUBSYSTEMS=="i2c"
    DRIVERS=="edt_ft5x06"
    ATTRS{offset}=="0"
    ATTRS{gain}=="0"
    ATTRS{report_rate}=="0"
    ATTRS{threshold}=="0"
    ATTRS{name}=="ft6236"

  looking at parent device '//devices/platform/soc/3f804000.i2c/i2c-1':
    KERNELS=="i2c-1"
    SUBSYSTEMS=="i2c"
    DRIVERS==""
    ATTRS{name}=="bcm2835 I2C adapter"

  looking at parent device '//devices/platform/soc/3f804000.i2c':
    KERNELS=="3f804000.i2c"
    SUBSYSTEMS=="platform"
    DRIVERS=="i2c-bcm2835"
    ATTRS{driver_override}=="(null)"

  looking at parent device '//devices/platform/soc':
    KERNELS=="soc"
    SUBSYSTEMS=="platform"
    DRIVERS==""
    ATTRS{driver_override}=="(null)"

  looking at parent device '//devices/platform':
    KERNELS=="platform"
    SUBSYSTEMS==""
    DRIVERS==""
```