### PR TITLE
1. See https://github.com/adafruit/Raspberry-Pi-Installer-Scripts/iss…

### DIFF
--- a/read-only-fs.sh
+++ b/read-only-fs.sh
@@ -281,20 +281,23 @@ replaceAppend /etc/ssh/sshd_config "^.*UsePrivilegeSeparation.*$" "UsePrivilegeS
 replace /usr/lib/tmpfiles.d/var.conf "spool\s*0755" "spool 1777"
 
 # Move dhcpd.resolv.conf to tmpfs
-touch /tmp/dhcpcd.resolv.conf
-rm /etc/resolv.conf
-ln -s /tmp/dhcpcd.resolv.conf /etc/resolv.conf
+#touch /tmp/dhcpcd.resolv.conf
+#rm /etc/resolv.conf
+#ln -s /tmp/dhcpcd.resolv.conf /etc/resolv.conf
 
 # Make edits to fstab
 # make / ro
 # tmpfs /var/log tmpfs nodev,nosuid 0 0
 # tmpfs /var/tmp tmpfs nodev,nosuid 0 0
 # tmpfs /tmp     tmpfs nodev,nosuid 0 0
-replace /etc/fstab "vfat\s*defaults\s" "vfat    defaults,ro "
-replace /etc/fstab "ext4\s*defaults,noatime\s" "ext4    defaults,noatime,ro "
+replace /etc/fstab "vfat\s*defaults\s.*" "vfat    defaults,ro\t0\t0"
+replace /etc/fstab "ext4\s*defaults,noatime\s.*" "ext4    defaults,noatime,ro\t0\t0"
 append1 /etc/fstab "/var/log" "tmpfs /var/log tmpfs nodev,nosuid 0 0"
 append1 /etc/fstab "/var/tmp" "tmpfs /var/tmp tmpfs nodev,nosuid 0 0"
 append1 /etc/fstab "\s/tmp"   "tmpfs /tmp    tmpfs nodev,nosuid 0 0"
+
+# Stop vim creating tmp files in ~/.viminfo (ro)
+echo 'set viminfo=""' >>/etc/vim/vimrc.local
 
 # PROMPT FOR REBOOT --------------------------------------------------------
 


### PR DESCRIPTION
1. See https://github.com/adafruit/Raspberry-Pi-Installer-Scripts/issues/92
ntpd started from 'systemctl' (via dhcpcd hook) can not follow symlink
from /etc/resolv.conf to /tmp/dhcpcd.resolv.conf. For now should remain
in /etc/resolv.conf (hard coded). 

stat64("/etc/resolv.conf", 0xbea7af80) = -1 ENOENT (No such file or directory)

2. Never fsck on any volume. Linux runs a fsck every 6 month even on
ro volumes. Any fs corruption makes fsck stall during boot-up and
requires user to confirm to continue.

3. Disable viminfo to stop vim from complaining about ~/.viminfo not
writeable.