### PR TITLE
Ntp fix etc

### DIFF
--- a/read-only-fs.sh
+++ b/read-only-fs.sh
@@ -281,20 +281,23 @@ replaceAppend /etc/ssh/sshd_config "^.*UsePrivilegeSeparation.*$" "UsePrivilegeS
 replace /usr/lib/tmpfiles.d/var.conf "spool\s*0755" "spool 1777"
 
 # Move dhcpd.resolv.conf to tmpfs
-touch /tmp/dhcpcd.resolv.conf
-rm /etc/resolv.conf
-ln -s /tmp/dhcpcd.resolv.conf /etc/resolv.conf
+#touch /tmp/dhcpcd.resolv.conf
+#rm /etc/resolv.conf
+#ln -s /tmp/dhcpcd.resolv.conf /etc/resolv.conf
 
 # Make edits to fstab
 # make / ro
 # tmpfs /var/log tmpfs nodev,nosuid 0 0
 # tmpfs /var/tmp tmpfs nodev,nosuid 0 0
 # tmpfs /tmp     tmpfs nodev,nosuid 0 0
-replace /etc/fstab "vfat\s*defaults\s" "vfat    defaults,ro "
-replace /etc/fstab "ext4\s*defaults,noatime\s" "ext4    defaults,noatime,ro "
+replace /etc/fstab "vfat\s*defaults\s.*" "vfat    defaults,ro\t0\t0"
+replace /etc/fstab "ext4\s*defaults,noatime\s.*" "ext4    defaults,noatime,ro\t0\t0"
 append1 /etc/fstab "/var/log" "tmpfs /var/log tmpfs nodev,nosuid 0 0"
 append1 /etc/fstab "/var/tmp" "tmpfs /var/tmp tmpfs nodev,nosuid 0 0"
 append1 /etc/fstab "\s/tmp"   "tmpfs /tmp    tmpfs nodev,nosuid 0 0"
+
+# Stop vim creating tmp files in ~/.viminfo (ro)
+echo 'set viminfo=""' >>/etc/vim/vimrc.local
 
 # PROMPT FOR REBOOT --------------------------------------------------------
 

--- a/read-only-fs.sh
+++ b/read-only-fs.sh
@@ -281,9 +281,11 @@ replaceAppend /etc/ssh/sshd_config "^.*UsePrivilegeSeparation.*$" "UsePrivilegeS
 replace /usr/lib/tmpfiles.d/var.conf "spool\s*0755" "spool 1777"
 
 # Move dhcpd.resolv.conf to tmpfs
-#touch /tmp/dhcpcd.resolv.conf
-#rm /etc/resolv.conf
-#ln -s /tmp/dhcpcd.resolv.conf /etc/resolv.conf
+touch /tmp/dhcpcd.resolv.conf
+rm /etc/resolv.conf
+ln -s /tmp/dhcpcd.resolv.conf /etc/resolv.conf
+# systemd-ntp must use systemwide /tmp to access /tmp/dhcpcd.resolv.conf
+replace /lib/systemd/system/ntp.service "PrivateTmp=true" "PrivateTmp=false"
 
 # Make edits to fstab
 # make / ro


### PR DESCRIPTION
1. tmpfs and systemctl on latest raspberry os breask ntp because /tmp is private to ntp. This results in /etc/resolv.conf symbolic link to became unavailable to ntpd. 

2. read-only fs should never be fsck'ed if 'reliability' and 'boot at all cost even fs is corrupted' is the goal. Otherwise linux will check fs every 6 month (including read only fs) and if corruption is found will wait for user to confirm to continue - you dont want this.

3. fixed vim complaining about ~/.viminfo not being writable.