### PR TITLE
Fix 80 row offset issue for 1.3" display

### DIFF
--- a/adafruit-pitft.py
+++ b/adafruit-pitft.py
@@ -118,7 +118,7 @@ dtoverlay=pitft28-capacitive,{rotation}""",
         "kernel_upgrade": True,
         "overlay_src": "overlays/minipitft13-overlay.dts",
         "overlay_dest": "/boot/overlays/drm-minipitft13.dtbo",
-        "overlay": "dtoverlay=drm-minipitft13,rotate={pitftrot}",
+        "overlay": "dtoverlay=drm-minipitft13,rotation={pitftrot}",
         "width": 240,
         "height": 240,
     },
@@ -237,7 +237,7 @@ def update_configtxt(rotation_override=None):
         if not shell.run_command("sudo apt-get update", True):
             warn_exit("Apt failed to update itself!")
         print("Upgrading packages...")
-        if not shell.run_command("sudo apt-get upgrade", True):
+        if not shell.run_command("sudo apt-get upgrade", False):
             warn_exit("Apt failed to install software!")
         print("Installing Kernel Headers...")
         if not shell.run_command("apt-get install -y raspberrypi-kernel-headers", True):
@@ -400,7 +400,7 @@ def install_fbcp():
         shell.reconfig("/boot/config.txt", "^.*display_hdmi_rotate.*$", "")
 
     if pitftrot in ("0", "180"):
-        display_rotate = "3" if pitftrot == "180" else "0"
+        display_rotate = "3" if pitftrot == "180" else "1"
         shell.reconfig("/boot/config.txt", "^.*display_hdmi_rotate.*$", "display_hdmi_rotate={}".format(display_rotate))
         # Because we rotate HDMI we have to 'unrotate' the TFT by overriding pitftrot!
         if not update_configtxt(90):

--- a/overlays/minipitft13-overlay.dts
+++ b/overlays/minipitft13-overlay.dts
@@ -7,65 +7,72 @@
 /plugin/;
 
 / {
-        compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
 
-        fragment@0 {
-                target = <&spi0>;
-                __overlay__ {
-                        status = "okay";
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			status = "okay";
 
-                        spidev@0{
-                                status = "disabled";
-                        };
+			spidev@0{
+				status = "disabled";
+			};
 
-                        spidev@1{
-                                status = "disabled";
-                        };
-                };
-        };
+		};
+	};
 
-        fragment@1 {
-                target = <&gpio>;
-                __overlay__ {
-                        pitft_pins: pitft_pins {
-                                brcm,pins = <25>;
-                                brcm,function = <1>; /* out */
-                                brcm,pull = <0>; /* none */
-                        };
-                };
-        };
+	fragment@1 {
+		target = <&gpio>;
+		__overlay__ {
+			pitft_pins: pitft_pins {
+				brcm,pins = <25>; /* dc pin */
+				brcm,function = <1>; /* out */
+				brcm,pull = <0>; /* no pull */
+			};
+		};
+	};
 
-        fragment@2 {
-                target = <&spi0>;
-                __overlay__ {
-                        /* needed to avoid dtc warning */
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+	fragment@2 {
+		target = <&spi0>;
+		__overlay__ {
+			/* needed to avoid dtc warning */
+			#address-cells = <1>;
+			#size-cells = <0>;
 
-                        pitft: pitft@0{
-                				compatible = "sitronix,st7789v";
-                                reg = <0>;
-                                pinctrl-names = "default";
-                                pinctrl-0 = <&pitft_pins>;
-                                spi-max-frequency = <32000000>;
-                                rotate = <0>;
-                                width = <240>;
-                                height = <240>;
-                                buswidth = <8>;
-                                dc-gpios = <&gpio 25 0>;
-                                led-gpios = <&gpio 26 0>;
-                                debug = <0>;
-                        };
-                };
-        };
+			pitft: pitft@0{
+				compatible = "multi-inno,mi0283qt";
+				reg = <0>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&pitft_pins>;
 
+				spi-max-frequency = <32000000>;
+				rotation = <0>;
+				width = <240>;
+				height = <240>;
+				col_offset = <0>;
+				row_offset = <0>;
+				dc-gpios = <&gpio 25 0>;
+				backlight = <&backlight>;
+			};
+		};
+	};
 
-        __overrides__ {
-                speed =   <&pitft>,"spi-max-frequency:0";
-                rotate =  <&pitft>,"rotate:0";
-                width =   <&pitft>,"width:0";
-                height =  <&pitft>,"height:0";
-                fps =     <&pitft>,"fps:0";
-                debug =   <&pitft>,"debug:0";
-        };
+	fragment@3 {
+		target-path = "/soc";
+		__overlay__ {
+			backlight: backlight {
+				compatible = "gpio-backlight";
+				gpios = <&gpio 26 0>;
+			};
+		};
+	};
+
+	__overrides__ {
+		speed =       <&pitft>,"spi-max-frequency:0";
+		rotation =    <&pitft>,"rotation:0";
+		width =       <&pitft>,"width:0";
+		height =      <&pitft>,"height:0";
+		col_offset =  <&pitft>,"col_offset:0";
+		row_offset =  <&pitft>,"row_offset:0";
+	};
 };


### PR DESCRIPTION
Fixes #128. It looks like something changed with driver and it was not working in rotations other than 0. I used the driver for the 1.14" and adjusted the backlight pin. Tested with MiniPiTFT 1.3", PiTFT Bonnet 1.3", and BrainCraft HAT. Tested with various rotations in console and HDMI mirroring with successful results. Also fixed an issue where setting rotation to 0 ended up with 90 degree rotation due to a typo.