### PR TITLE
Roll back driver + couple small script fixes

### DIFF
--- a/adafruit-pitft.py
+++ b/adafruit-pitft.py
@@ -237,7 +237,7 @@ def update_configtxt(rotation_override=None):
         if not shell.run_command("sudo apt-get update", True):
             warn_exit("Apt failed to update itself!")
         print("Upgrading packages...")
-        if not shell.run_command("sudo apt-get upgrade", False):
+        if not shell.run_command("sudo apt-get -y upgrade", False):
             warn_exit("Apt failed to install software!")
         print("Installing Kernel Headers...")
         if not shell.run_command("apt-get install -y raspberrypi-kernel-headers", True):
@@ -381,7 +381,7 @@ def install_fbcp():
     shell.reconfig("/boot/config.txt", "^.*hdmi_force_hotplug.*$", "hdmi_force_hotplug=1")
     shell.reconfig("/boot/config.txt", "^.*hdmi_group.*$", "hdmi_group=2")
     shell.reconfig("/boot/config.txt", "^.*hdmi_mode.*$", "hdmi_mode=87")
-    shell.reconfig("/boot/config.txt", "^[^#]*dtoverlay=vc4-fkms-v3d.*$", "#dtoverlay=vc4-fkms-v3d")
+    shell.pattern_replace("/boot/config.txt", "^[^#]*dtoverlay=vc4-fkms-v3d.*$", "#dtoverlay=vc4-fkms-v3d")
 
     # if there's X11 installed...
     scale = 1
@@ -431,7 +431,7 @@ def uninstall_fbcp():
     shell.run_command("raspi-config nonint do_overscan 0")
     print("Configuring boot/config.txt for default HDMI")
     shell.reconfig("/boot/config.txt", "^.*hdmi_force_hotplug.*$", "hdmi_force_hotplug=0")
-    shell.reconfig("/boot/config.txt", "^.*#.*dtoverlay=vc4-fkms-v3d.*$", "dtoverlay=vc4-fkms-v3d")
+    shell.pattern_replace("/boot/config.txt", "^.*#.*dtoverlay=vc4-fkms-v3d.*$", "dtoverlay=vc4-fkms-v3d")
     shell.pattern_replace("/boot/config.txt", '^hdmi_group=2.*$')
     shell.pattern_replace("/boot/config.txt", '^hdmi_mode=87.*$')
     shell.pattern_replace("/boot/config.txt", '^hdmi_cvt=.*$')

--- a/overlays/minipitft13-overlay.dts
+++ b/overlays/minipitft13-overlay.dts
@@ -7,72 +7,65 @@
 /plugin/;
 
 / {
-	compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
+        compatible = "brcm,bcm2835", "brcm,bcm2708", "brcm,bcm2709";
 
-	fragment@0 {
-		target = <&spi0>;
-		__overlay__ {
-			status = "okay";
+        fragment@0 {
+                target = <&spi0>;
+                __overlay__ {
+                        status = "okay";
 
-			spidev@0{
-				status = "disabled";
-			};
+                        spidev@0{
+                                status = "disabled";
+                        };
 
-		};
-	};
+                        spidev@1{
+                                status = "disabled";
+                        };
+                };
+        };
 
-	fragment@1 {
-		target = <&gpio>;
-		__overlay__ {
-			pitft_pins: pitft_pins {
-				brcm,pins = <25>; /* dc pin */
-				brcm,function = <1>; /* out */
-				brcm,pull = <0>; /* no pull */
-			};
-		};
-	};
+        fragment@1 {
+                target = <&gpio>;
+                __overlay__ {
+                        pitft_pins: pitft_pins {
+                                brcm,pins = <25>;
+                                brcm,function = <1>; /* out */
+                                brcm,pull = <0>; /* none */
+                        };
+                };
+        };
 
-	fragment@2 {
-		target = <&spi0>;
-		__overlay__ {
-			/* needed to avoid dtc warning */
-			#address-cells = <1>;
-			#size-cells = <0>;
+        fragment@2 {
+                target = <&spi0>;
+                __overlay__ {
+                        /* needed to avoid dtc warning */
+                        #address-cells = <1>;
+                        #size-cells = <0>;
 
-			pitft: pitft@0{
-				compatible = "multi-inno,mi0283qt";
-				reg = <0>;
-				pinctrl-names = "default";
-				pinctrl-0 = <&pitft_pins>;
+                        pitft: pitft@0{
+                				compatible = "sitronix,st7789v";
+                                reg = <0>;
+                                pinctrl-names = "default";
+                                pinctrl-0 = <&pitft_pins>;
+                                spi-max-frequency = <32000000>;
+                                rotate = <0>;
+                                width = <240>;
+                                height = <240>;
+                                buswidth = <8>;
+                                dc-gpios = <&gpio 25 0>;
+                                led-gpios = <&gpio 26 0>;
+                                debug = <0>;
+                        };
+                };
+        };
 
-				spi-max-frequency = <32000000>;
-				rotation = <0>;
-				width = <240>;
-				height = <240>;
-				col_offset = <0>;
-				row_offset = <0>;
-				dc-gpios = <&gpio 25 0>;
-				backlight = <&backlight>;
-			};
-		};
-	};
 
-	fragment@3 {
-		target-path = "/soc";
-		__overlay__ {
-			backlight: backlight {
-				compatible = "gpio-backlight";
-				gpios = <&gpio 26 0>;
-			};
-		};
-	};
-
-	__overrides__ {
-		speed =       <&pitft>,"spi-max-frequency:0";
-		rotation =    <&pitft>,"rotation:0";
-		width =       <&pitft>,"width:0";
-		height =      <&pitft>,"height:0";
-		col_offset =  <&pitft>,"col_offset:0";
-		row_offset =  <&pitft>,"row_offset:0";
-	};
+        __overrides__ {
+                speed =   <&pitft>,"spi-max-frequency:0";
+                rotate =  <&pitft>,"rotate:0";
+                width =   <&pitft>,"width:0";
+                height =  <&pitft>,"height:0";
+                fps =     <&pitft>,"fps:0";
+                debug =   <&pitft>,"debug:0";
+        };
 };


### PR DESCRIPTION
This rolls back the 1.3" driver due to issues users were having with the braincraft hat. This also has a couple small script fixes including apt upgrade was waiting for user input, but not letting the user know to press Y. Some extra "#dtoverlay=vc4-fkms-v3d" were being added to the config which was annoying.