### PR TITLE
Add pinning to pitft and fix driver

### DIFF
--- a/adafruit-pitft.py
+++ b/adafruit-pitft.py
@@ -152,6 +152,8 @@ SYSTEMD = None
 pitft_config = None
 pitftrot = None
 auto_reboot = None
+force_kernel = "5.4"
+force_kernel_release = "1.20201126-1"
 
 def warn_exit(message):
     shell.warn(message)
@@ -238,6 +240,10 @@ def update_configtxt(rotation_override=None):
         print("Upgrading packages...")
         if not shell.run_command("sudo apt-get -y upgrade", False):
             warn_exit("Apt failed to install software!")
+        if force_kernel and force_kernel + '.' not in shell.release():
+            print("Pinning kernel to version {}".format(force_kernel))
+            if not shell.run_command("sudo sh rpi-pin-kernel-firmware.sh {}".format(force_kernel_release), True):
+                warn_exit("Failed to pin all kernel files!")
         print("Installing Kernel Headers...")
         if not shell.run_command("apt-get install -y raspberrypi-kernel-headers", True):
             warn_exit("Apt failed to install software!")


### PR DESCRIPTION
Ok, this PR does 2 things.
First it fixes the driver so it compiles under Kernel 5.10 and 5.4.
Second, it runs the pinning script as part of the PiTFT install process if the version is greater than 5.4.
Fixes #149.