### PR TITLE
Dependency check for RPi.GPIO

### DIFF
--- a/raspi-blinka.py
+++ b/raspi-blinka.py
@@ -62,8 +62,9 @@ def update_pip():
 def install_blinka():
     print("Installing latest version of Blinka locally")
     shell.run_command("sudo apt-get install -y i2c-tools")
+    shell.run_command("pip3 install --upgrade RPi.GPIO")
     shell.run_command("pip3 install --upgrade adafruit-blinka")
-    
+
 def main():
     global default_python
     shell.clear()


### PR DESCRIPTION
Dependency check for RPi.GPIO which is a dependancy for: Adafruit_Blinka/src/adafruit_blinka/microcontroller/bcm283x/pin.py

RPi.GPIO is not included in all Raspberry Pi OS images and may not be installed on the host E.G. Raspberry Pi OS Lite.