### PR TITLE
Only do package update, no system upgrade

### DIFF
--- a/raspi-blinka.py
+++ b/raspi-blinka.py
@@ -34,7 +34,7 @@ def check_blinka_python_version():
     if get_python3_version() < blinka_minimum_python_version:
         shell.bail("Blinka requires a minimum of Python version {} to install. Please update your OS!".format(blinka_minimum_python_version))
     
-def sys_update():   
+def sys_update():
     print("Updating System Packages")
     if not shell.run_command("sudo apt-get update"):
         shell.bail("Apt failed to update indexes!")

--- a/raspi-blinka.py
+++ b/raspi-blinka.py
@@ -38,9 +38,6 @@ def sys_update():
     print("Updating System Packages")
     if not shell.run_command("sudo apt-get update"):
         shell.bail("Apt failed to update indexes!")
-    print("Upgrading packages...")
-    if not shell.run_command("sudo apt-get -y upgrade"):
-        shell.bail("Apt failed to install software!")
 
 def set_raspiconfig():
     """

--- a/raspi-blinka.py
+++ b/raspi-blinka.py
@@ -34,10 +34,14 @@ def check_blinka_python_version():
     if get_python3_version() < blinka_minimum_python_version:
         shell.bail("Blinka requires a minimum of Python version {} to install. Please update your OS!".format(blinka_minimum_python_version))
     
-def sys_update():
+def sys_update():   
     print("Updating System Packages")
     if not shell.run_command("sudo apt-get update"):
         shell.bail("Apt failed to update indexes!")
+    if shell.prompt("Would you like to upgrade system packages now?", default="y"):
+        print("Upgrading packages...")
+        if not shell.run_command("sudo apt-get -y upgrade"):
+            shell.bail("Apt failed to install software!")        
 
 def set_raspiconfig():
     """


### PR DESCRIPTION
The guides already say to to an upgrade before even running this script and the way this works right now it just hangs for a long time without any feedback for sometimes 10-20 minutes.
This is I think not a very good UX. See this issue on more reasoning: https://github.com/adafruit/Raspberry-Pi-Installer-Scripts/issues/174
The default nature of upgrading all the system packages is I think a bit too many changes than one would expect from installing a python package.