### PR TITLE
Change backlight on ST7789 displays to be on by default

### DIFF
--- a/overlays/minipitft114-overlay.dts
+++ b/overlays/minipitft114-overlay.dts
@@ -53,7 +53,7 @@
                                 height = <240>;
                                 buswidth = <8>;
                                 dc-gpios = <&gpio 25 0>;
-                                led-gpios = <&gpio 26 0>;
+                                led-gpios = <&gpio 26 1>;
                                 debug = <0>;
                         };
                 };

--- a/overlays/minipitft13-overlay.dts
+++ b/overlays/minipitft13-overlay.dts
@@ -53,7 +53,7 @@
                                 height = <240>;
                                 buswidth = <8>;
                                 dc-gpios = <&gpio 25 0>;
-                                led-gpios = <&gpio 26 0>;
+                                led-gpios = <&gpio 26 1>;
                                 debug = <0>;
                         };
                 };

--- a/overlays/st7789v_240x320-overlay.dts
+++ b/overlays/st7789v_240x320-overlay.dts
@@ -53,7 +53,7 @@
                                 height = <320>;
                                 buswidth = <8>;
                                 dc-gpios = <&gpio 25 0>;
-                                led-gpios = <&gpio 12 0>;
+                                led-gpios = <&gpio 12 1>;
                                 debug = <0>;
                         };
                 };

--- a/overlays/tftbonnet13-overlay.dts
+++ b/overlays/tftbonnet13-overlay.dts
@@ -53,7 +53,7 @@
                                 height = <240>;
                                 buswidth = <8>;
                                 dc-gpios = <&gpio 25 0>;
-                                led-gpios = <&gpio 26 0>;
+                                led-gpios = <&gpio 26 1>;
                                 debug = <0>;
                         };
                 };


### PR DESCRIPTION
Hard to believe the fix was so simple, but when you run out of documented suggestions that don't seem to work and just start trying your own wacky ideas, sometimes it just works out that way.
Fixes #187. Fixes #189.