### PR TITLE
read-only-fs.sh: exit with message, only keeping this temporarily

### DIFF
--- a/read-only-fs.sh
+++ b/read-only-fs.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+echo "NEWS: see https://learn.adafruit.com/read-only-raspberry-pi"
+echo "This script is deprecated, with better functionality now in"
+echo "the OS without hacks. It's being kept temporarily for reference."
+echo "You can edit this part out if you really need to run it."
+exit 0
+
 # CREDIT TO THESE TUTORIALS:
 # petr.io/en/blog/2015/11/09/read-only-raspberry-pi-with-jessie
 # hallard.me/raspberry-pi-read-only


### PR DESCRIPTION
This script is neutralized (exits on startup after a brief message) but I’m not comfortable deleting it yet, in case someone was still relying on it. Perhaps in a few months or a year if there’s no activity, it can be removed.