### PR TITLE
Updated backlight to be on for latest kernel

### DIFF
--- a/overlays/minipitft114-overlay.dts
+++ b/overlays/minipitft114-overlay.dts
@@ -54,7 +54,7 @@
                                 txbuflen = <32768>;
                                 buswidth = <8>;
                                 dc-gpios = <&gpio 25 0>;
-                                led-gpios = <&gpio 26 1>;
+                                led-gpios = <&gpio 26 0>;
                                 debug = <0>;
                         };
                 };

--- a/overlays/minipitft13-overlay.dts
+++ b/overlays/minipitft13-overlay.dts
@@ -54,7 +54,7 @@
                                 txbuflen = <32768>;
                                 buswidth = <8>;
                                 dc-gpios = <&gpio 25 0>;
-                                led-gpios = <&gpio 26 1>;
+                                led-gpios = <&gpio 26 0>;
                                 debug = <0>;
                         };
                 };

--- a/overlays/st7789v_240x320-overlay.dts
+++ b/overlays/st7789v_240x320-overlay.dts
@@ -54,7 +54,7 @@
                                 txbuflen = <32768>;
                                 buswidth = <8>;
                                 dc-gpios = <&gpio 25 0>;
-                                led-gpios = <&gpio 12 1>;
+                                led-gpios = <&gpio 12 0>;
                                 debug = <0>;
                         };
                 };

--- a/overlays/tftbonnet13-overlay.dts
+++ b/overlays/tftbonnet13-overlay.dts
@@ -53,7 +53,7 @@
                                 height = <240>;
                                 buswidth = <8>;
                                 dc-gpios = <&gpio 25 0>;
-                                led-gpios = <&gpio 26 1>;
+                                led-gpios = <&gpio 26 0>;
                                 debug = <0>;
                         };
                 };


### PR DESCRIPTION
Raspberry Pi updated the kernel again and now the backlight is off by default. This PR basically undos #192, which seems to fix it.