### PR TITLE
fix(adafruit-pitft.py): libts dependency

### DIFF
--- a/adafruit-pitft.py
+++ b/adafruit-pitft.py
@@ -238,7 +238,8 @@ def softwareinstall():
     print("Installing Pre-requisite Software...This may take a few minutes!")
     if not shell.run_command("apt-get install -y libts0", True):
         if not shell.run_command("apt-get install -y tslib"):
-            warn_exit("Apt failed to install TSLIB!")
+            if not shell.run_command("apt-get install -y libts-dev"):
+                warn_exit("Apt failed to install TSLIB!")
     if not shell.run_command("apt-get install -y bc fbi git python3-dev python3-pip python3-smbus python3-spidev evtest libts-bin device-tree-compiler libraspberrypi-dev build-essential"):
         warn_exit("Apt failed to install software!")
     if not shell.run_command("pip3 install evdev"):


### PR DESCRIPTION
Working with the Raspberry Pi Zero 2 W and ran into the error state where whenever I was attempting to install adafruit-pitft.py installer (`sudo python3 adafruit-pitft.py`) it would not find the libts dependency. Upon investigating, it seems like on Buster the library exists but is not indexable. 

This issue is solved by installing the libts-dev dependency.

