### PR TITLE
docs: add an alternative package if original fails

### DIFF
--- a/libgpiod.py
+++ b/libgpiod.py
@@ -1,9 +1,7 @@
 # Instructions!
 # cd ~
 # sudo apt-get install python3-pip
-# sudo pip3 install --upgrade adafruit-python3-shell click 
-#   => NOTE: if the adafruit library fails, try installing
-#            the adafruit-python-shell package instead.
+# sudo pip3 install --upgrade adafruit-python-shell click
 # wget https://raw.githubusercontent.com/adafruit/Raspberry-Pi-Installer-Scripts/master/libgpiod.py
 # sudo python3 libgpiod.py
 

--- a/libgpiod.py
+++ b/libgpiod.py
@@ -1,7 +1,9 @@
 # Instructions!
 # cd ~
 # sudo apt-get install python3-pip
-# sudo pip3 install --upgrade adafruit-python3-shell click
+# sudo pip3 install --upgrade adafruit-python3-shell click 
+#   => NOTE: if the adafruit library fails, try installing
+#            the adafruit-python-shell package instead.
 # wget https://raw.githubusercontent.com/adafruit/Raspberry-Pi-Installer-Scripts/master/libgpiod.py
 # sudo python3 libgpiod.py
 


### PR DESCRIPTION
The old instructions mentioned adafruit-python**3**-shell as a dependency but when I tried to install the package I found out that the package didn't exist ( or deprecated I think ) and I was able to use adafruit-python-shell instead. So, I thought I might add the package to the instructions in case anyone else runs into the same issue as me.