### PR TITLE
Fix Capacitive 2.8-inch PiTFT touch

### DIFF
--- a/adafruit-pitft.py
+++ b/adafruit-pitft.py
@@ -19,7 +19,7 @@ except ImportError:
 shell = Shell()
 shell.group = 'PITFT'
 
-__version__ = "3.4.0"
+__version__ = "3.5.0"
 
 """
 This is the main configuration. Displays should be placed in the order
@@ -76,14 +76,8 @@ config = [
             },
         },
         "overlay": """dtoverlay=pitft28-capacitive,speed=64000000,fps=30
-dtoverlay=pitft28-capacitive,{rotation}""",
+dtoverlay=pitft28-capacitive,rotate={pitftrot}""",
         "calibrations": "320 65536 0 -65536 0 15728640 65536",
-        "rotations": {
-            "0": "rotate=90,touch-invx=true,touch-invy=true",
-            "90": "rotate=90,touch-swapxy=true,touch-invx=true",
-            "180": "rotate=90",
-            "270": "rotate=270,touch-swapxy=true,touch-invy=true",
-        },
         "width": 320,
         "height": 240,
     },
@@ -318,8 +312,6 @@ def update_configtxt(rotation_override=None):
     if "{pitftrot}" in overlay:
         rotation = str(rotation_override) if rotation_override is not None else pitftrot
         overlay = overlay.format(pitftrot=rotation)
-    if "{rotation}" in overlay and isinstance(pitft_config['rotations'], dict) and pitft_config['rotations'][pitftrot] is not None:
-        overlay = overlay.format(rotation=pitft_config['rotations'][pitftrot])
 
     shell.write_text_file(f"{boot_dir}/config.txt", """
 # --- added by adafruit-pitft-helper {date} ---

--- a/i2smic.py
+++ b/i2smic.py
@@ -7,12 +7,6 @@ except ImportError:
 
 shell = Shell()
 
-def is_kernel_userspace_mismatch():
-    """
-    Check if the userspace is 64-bit
-    """
-    return platform.machine() == "aarch64" and platform.architecture()[0] == "32bit"
-
 def main():
     shell.clear()
     print("""This script downloads and installs
@@ -31,13 +25,6 @@ I2S microphone support.
     else:
         shell.bail("Unsupported Pi board detected.")
 
-    if shell.is_arm64() and is_kernel_userspace_mismatch():
-        print("Unable to compile driver because kernel space is 64-bit, but user space is 32-bit.")
-        if shell.prompt("Add parameter to /boot/config.txt to use 32-bit kernel?"):
-            shell.reconfig("/boot/config.txt", "^.*arm_64bit.*$", "arm_64bit=0")
-            shell.prompt_reboot()
-        else:
-            shell.bail("Unable to continue while mismatch is present.")
     auto_load = (
         not shell.argument_exists('noautoload') and
         shell.prompt("Auto load module at boot?", force_arg="autoload"))
@@ -82,4 +69,5 @@ Settings take effect on next boot.
 # Main function
 if __name__ == "__main__":
     shell.require_root()
+    shell.check_kernel_userspace_mismatch()
     main()


### PR DESCRIPTION
Fixes #248. OS apparently handles adjusting the touch stuff automatically now, so removed our invert parameters.

Tagging @ladyada.