### PR TITLE
Please restore i2samp.h support for Raspbian buster system.

### DIFF
--- a/i2samp.sh
+++ b/i2samp.sh
@@ -235,7 +235,7 @@ raspbian_check() {
         elif cat /etc/os-release | grep "bullseye" > /dev/null; then
             IS_SUPPORTED=false && IS_EXPERIMENTAL=true
         elif cat /etc/os-release | grep "buster" > /dev/null; then
-            IS_SUPPORTED=false && IS_EXPERIMENTAL=false
+            IS_SUPPORTED=false && IS_EXPERIMENTAL=true
         elif cat /etc/os-release | grep "stretch" > /dev/null; then
             IS_SUPPORTED=false && IS_EXPERIMENTAL=false
         elif cat /etc/os-release | grep "jessie" > /dev/null; then


### PR DESCRIPTION
Please restore i2samp.h support for Raspbian buster system. I test the i2s driver on the raspbian buster system, everything works fine.