### PR TITLE
Fix bug in python version check in raspi-blinka.py

### DIFF
--- a/raspi-blinka.py
+++ b/raspi-blinka.py
@@ -42,7 +42,7 @@ def check_blinka_python_version():
     current_major, current_minor = current.split(".")[0:2]
     required_major, required_minor = str(blinka_minimum_python_version).split(".")[0:2]
 
-    if current_major >= required_major and current_minor >= required_minor:
+    if int(current_major) >= int(required_major) and int(current_minor) >= int(required_minor):
         return
 
     shell.bail("Blinka requires a minimum of Python version {} to install, current one is {}. Please update your OS!".format(blinka_minimum_python_version, current))


### PR DESCRIPTION
The file checked the python version by comparing the major and minor versions. However, the variables compared were strings, making '11' > '8' -> False, when in fact it should have been true. I converted the versions to integers before comparing, so that versions 10 and above are accepted.