### PR TITLE
Update raspi-config serial enable

### DIFF
--- a/raspi-blinka.py
+++ b/raspi-blinka.py
@@ -64,7 +64,7 @@ def set_raspiconfig():
     print("Enabling SPI")
     shell.run_command("sudo raspi-config nonint do_spi 0")
     print("Enabling Serial")
-    shell.run_command("sudo raspi-config nonint do_serial 0")
+    shell.run_command("sudo raspi-config nonint do_serial_hw 0")
     print("Enabling SSH")
     shell.run_command("sudo raspi-config nonint do_ssh 0")
     print("Enabling Camera")


### PR DESCRIPTION
Looks like the parameter for configuring serial non-interactively has changed. This PR updates it.