### PR TITLE
Bump `rpi-rgb-led-matrix` commit to `a3eea9`

### DIFF
--- a/rgb-matrix.sh
+++ b/rgb-matrix.sh
@@ -7,7 +7,8 @@
 # we reference a specific commit (update this as needed):
 GITUSER=https://github.com/hzeller
 REPO=rpi-rgb-led-matrix
-COMMIT=45d3ab5d6cff6e0c14da58930d662822627471fc #needs updated if This is merged/Released
+COMMIT=a3eea997a9254b83ab2de97ae80d83588f696387
+# Previously: COMMIT=45d3ab5d6cff6e0c14da58930d662822627471fc
 # Previously: COMMIT=21410d2b0bac006b4a1661594926af347b3ce334
 # Previously: COMMIT=e3dd56dcc0408862f39cccc47c1d9dea1b0fb2d2 
 


### PR DESCRIPTION
When using [`rgb-matrix.sh`](https://github.com/adafruit/Raspberry-Pi-Installer-Scripts/blob/main/rgb-matrix.sh) on newer RPi OS (which ship with Python 3.11), we run into issues like https://github.com/hzeller/rpi-rgb-led-matrix/issues/1526 when trying to use this installer since Python 3.11 doesn't expose that header anymore (see https://github.com/cython/cython/issues/4461).

This PR just bumps the `rpi-rgb-led-matrix` commit to the newest version, that also includes a fix for the above problem.

