### PR TITLE
Update i2samp to work on bookworm

### DIFF
--- a/i2samp.sh
+++ b/i2samp.sh
@@ -46,8 +46,8 @@ ASK_TO_REBOOT=false
 CURRENT_SETTING=false
 UPDATE_DB=false
 
-BOOTCMD=/boot/cmdline.txt
-CONFIG=/boot/config.txt
+BOOTCMD=/boot/firmware/cmdline.txt
+CONFIG=/boot/firmware/config.txt
 APTSRC=/etc/apt/sources.list
 INITABCONF=/etc/inittab
 BLACKLIST=/etc/modprobe.d/raspi-blacklist.conf

--- a/i2samp.sh
+++ b/i2samp.sh
@@ -54,6 +54,11 @@ BLACKLIST=/etc/modprobe.d/raspi-blacklist.conf
 LOADMOD=/etc/modules
 DTBODIR=/boot/overlays
 
+# Fall back to old location
+if ! test -f $CONFIG; then
+    CONFIG=/boot/config.txt
+fi
+
 # function define
 
 confirm() {


### PR DESCRIPTION
Fixes #270.

This change updates it to attempt to use the new location of config.txt first, but allows falling back for older OS. Otherwise it seemed to work fine.

cc: @ladyada for review