### PR TITLE
Fix mipi script from messing with kms and fkms drivers

### DIFF
--- a/adafruit-pitft-mipi.py
+++ b/adafruit-pitft-mipi.py
@@ -365,9 +365,6 @@ def install_mipi():
     # Disable overscan compensation (use full screen):
     shell.run_command("raspi-config nonint do_overscan 1")
 
-    shell.pattern_replace(f"{boot_dir}/config.txt", "^[^#]*dtoverlay=vc4-kms-v3d.*$", "#dtoverlay=vc4-kms-v3d")
-    shell.pattern_replace(f"{boot_dir}/config.txt", "^[^#]*dtoverlay=vc4-fkms-v3d.*$", "#dtoverlay=vc4-fkms-v3d")
-
     if not update_configtxt():
         shell.bail(f"Unable to update {boot_dir}/config.txt")
     return True


### PR DESCRIPTION
Tested the script on the Pi 5 with wayland and display works, but there was no desktop. Turns out the script was disabling the KMS driver. This fixes the issue.

cc: @ladyada for review