### PR TITLE
Update PiTFT Script and 2.2 inch overlay for Bookworm/Pi 5

### DIFF
--- a/overlays/pitft22-overlay.dts
+++ b/overlays/pitft22-overlay.dts
@@ -1,0 +1,63 @@
+/*
+ * Device Tree overlay for pitft by Adafruit
+ *
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+        compatible = "brcm,bcm2835";
+
+        fragment@0 {
+                target = <&spidev0>;
+                __overlay__ {
+                        status = "disabled";
+                };
+        };
+
+        fragment@1 {
+                target = <&spidev1>;
+                __overlay__ {
+                        status = "disabled";
+                };
+        };
+
+        fragment@2 {
+                target = <&gpio>;
+                __overlay__ {
+                        pitft_pins: pitft_pins {
+                                brcm,pins = <25>;
+                                brcm,function = <1>; /* out */
+                                brcm,pull = <0>; /* none */
+                        };
+                };
+        };
+
+        fragment@3 {
+                target = <&spi0>;
+                __overlay__ {
+                        /* needed to avoid dtc warning */
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+                        status = "okay";
+
+                        pitft: pitft@0{
+                                compatible = "adafruit,yx240qv29";
+                                reg = <0>;
+                                pinctrl-names = "default";
+                                pinctrl-0 = <&pitft_pins>;
+
+                                spi-max-frequency = <32000000>;
+                                rotation = <90>;
+                                dc-gpios = <&gpio 25 0>;
+                        };
+
+                };
+        };
+
+        __overrides__ {
+                speed =   <&pitft>,"spi-max-frequency:0";
+                rotate =  <&pitft>,"rotation:0";
+        };
+};


### PR DESCRIPTION
This updates the PiTFT script so that it works with bookworm, but still retains backwards compatibility for now. Since FBCP is going away, I added a new type called "mirror" which is basically the same thing, but more generalized. Wayland detection added, so it will guide the user down the correct path based on whether or not they are running Wayland.

cc: @ladyada  for review