### PR TITLE
Update PiTFT overlays and add resistive PiTFTs

### DIFF
--- a/adafruit-pitft.py
+++ b/adafruit-pitft.py
@@ -40,8 +40,17 @@ config = [
                 "180": "-1.115235 -0.010589 1.057967 -0.005964 -1.107968 1.025780 0 0 1",
                 "270": "-0.033192 1.126869 -0.014114 -1.115846 0.006580 1.050030 0 0 1",
             },
+            "overlay_params": {
+                "0": None,
+                "90": "touch-swapxy,touch-invx",
+                "180": "touch-invx,touch-invy",
+                "270": "touch-swapxy,touch-invy",
+            },
         },
-        "overlay": "dtoverlay=pitft28-resistive,rotate={pitftrot},speed=64000000,fps=30",
+        "overlay_src": "overlays/pitft28-resistive-overlay.dts",
+        "overlay_dest": "{boot_dir}/overlays/pitft28-resistive-adafruit.dtbo",
+        "overlay": "dtoverlay=pitft28-resistive-adafruit,rotate={pitftrot},speed=64000000,fps=30",
+	"overlay_drm_option": "drm",
         "calibrations": {
             "0": "4232 11 -879396 1 5786 -752768 65536",
             "90": "33 -5782 21364572 4221 35 -1006432 65536",
@@ -57,9 +66,9 @@ config = [
         "product": "2.2\" no touch",
         "kernel_upgrade": False,
         "overlay_src": "overlays/pitft22-overlay.dts",
-        "overlay_dest": "{boot_dir}/overlays/tinydrm-pitft22.dtbo",
-        "overlay": "dtoverlay=tinydrm-pitft22,rotate={pitftrot}",
-        "fb_overlay": "dtoverlay=pitft22,rotate={pitftrot},speed=64000000,fps=30",
+        "overlay_dest": "{boot_dir}/overlays/pitft22-adafruit.dtbo",
+        "overlay": "dtoverlay=pitft22,rotate={pitftrot},speed=64000000,fps=30",
+	"overlay_drm_option": "drm",
         "width": 320,
         "height": 240,
     },
@@ -85,10 +94,9 @@ config = [
             },
         },
         "overlay_src": "overlays/pitft28-capacitive-overlay.dts",
-        "overlay_dest": "{boot_dir}/overlays/tinydrm-pitft28-capacitive.dtbo",
-        "overlay": "dtoverlay=tinydrm-pitft28-capacitive,rotate={pitftrot}",
-        "fb_overlay": """dtoverlay=pitft28-capacitive,speed=64000000,fps=30
-dtoverlay=pitft28-capacitive,rotate={pitftrot}""",
+        "overlay_dest": "{boot_dir}/overlays/pitft28-capacitive-adafruit.dtbo",
+        "overlay": "dtoverlay=pitft28-capacitive-adafruit,rotate={pitftrot},speed=64000000,fps=30",
+	"overlay_drm_option": "drm",
         "calibrations": "320 65536 0 -65536 0 15728640 65536",
         "width": 320,
         "height": 240,
@@ -107,8 +115,17 @@ dtoverlay=pitft28-capacitive,rotate={pitftrot}""",
                 "180": "1.102807 0.000030 -0.066352 0.001374 1.085417 -0.027208 0 0 1",
                 "270": "0.003893 -1.087542 1.025913 1.084281 0.008762 -0.060700 0 0 1",
             },
+            "overlay_params": {
+                "0": None,
+                "90": "touch-swapxy,touch-invx",
+                "180": "touch-invx,touch-invy",
+                "270": "touch-swapxy,touch-invy",
+            },
         },
-        "overlay": "dtoverlay=pitft35-resistive,rotate={pitftrot},speed=20000000,fps=20",
+        "overlay_src": "overlays/pitft35-resistive-overlay.dts",
+        "overlay_dest": "{boot_dir}/overlays/pitft35-resistive-adafruit.dtbo",
+        "overlay": "dtoverlay=pitft35-resistive-adafruit,rotate={pitftrot},speed=20000000,fps=20",
+	"overlay_drm_option": "drm",
         "calibrations": {
             "0": "5724 -6 -1330074 26 8427 -1034528 65536",
             "90": "5 8425 -978304 -5747 61 22119468 65536",
@@ -325,12 +342,12 @@ def update_configtxt(rotation_override=None, tinydrm_install=False):
     uninstall_bootconfigtxt()
     uninstall_etc_modules()
     overlay_key = "overlay"
-    if not tinydrm_install and "fb_overlay" in pitft_config:
-        overlay_key = "fb_overlay"
     overlay = pitft_config[overlay_key]
     if "{pitftrot}" in overlay:
         rotation = str(rotation_override) if rotation_override is not None else pitftrot
         overlay = overlay.format(pitftrot=rotation)
+    if tinydrm_install and "overlay_drm_option" in pitft_config:
+        overlay += "," + pitft_config["overlay_drm_option"]
     if tinydrm_install: # Wayland ignores X11 Transformations, so use params instead
         if "overlay_params" in pitft_config and pitftrot in pitft_config["overlay_params"] and pitft_config["overlay_params"][pitftrot] is not None:
             overlay += "," + pitft_config["overlay_params"][pitftrot]
@@ -783,7 +800,7 @@ restart the script and choose a different orientation.""".format(rotation=pitftr
         mirror_prompt = "Would you like the HDMI display to mirror to the PiTFT display?"
         if wayland:
             # With wayland, PiTFT shows up as an additional display rather than a mirror
-            mirror_prompt = "Would you like the to use the PiTFT as an display?"
+            mirror_prompt = "Would you like the to use the PiTFT as a desktop display?"
         if install_type == "mirror" or (install_type is None and shell.prompt(mirror_prompt)):
             if wayland:
                 update_wayfire_settings()

--- a/overlays/pitft22-overlay.dts
+++ b/overlays/pitft22-overlay.dts
@@ -7,57 +7,65 @@
 /plugin/;
 
 / {
-        compatible = "brcm,bcm2835";
+	compatible = "brcm,bcm2835";
 
-        fragment@0 {
-                target = <&spidev0>;
-                __overlay__ {
-                        status = "disabled";
-                };
+	fragment@0 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
         };
 
-        fragment@1 {
-                target = <&spidev1>;
-                __overlay__ {
-                        status = "disabled";
-                };
-        };
+	fragment@1 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
 
-        fragment@2 {
-                target = <&gpio>;
-                __overlay__ {
-                        pitft_pins: pitft_pins {
-                                brcm,pins = <25>;
-                                brcm,function = <1>; /* out */
-                                brcm,pull = <0>; /* none */
-                        };
-                };
-        };
+	fragment@2 {
+		target = <&gpio>;
+		__overlay__ {
+			pitft_pins: pitft_pins {
+				brcm,pins = <25>;
+				brcm,function = <1>; /* out */
+				brcm,pull = <0>; /* none */
+			};
+		};
+	};
 
-        fragment@3 {
-                target = <&spi0>;
-                __overlay__ {
-                        /* needed to avoid dtc warning */
-                        #address-cells = <1>;
-                        #size-cells = <0>;
-                        status = "okay";
+	fragment@3 {
+		target = <&spi0>;
+		__overlay__ {
+			/* needed to avoid dtc warning */
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
 
-                        pitft: pitft@0{
-                                compatible = "adafruit,yx240qv29";
-                                reg = <0>;
-                                pinctrl-names = "default";
-                                pinctrl-0 = <&pitft_pins>;
+			pitft: pitft@0{
+				compatible = "ilitek,ili9340";
+				reg = <0>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&pitft_pins>;
 
-                                spi-max-frequency = <32000000>;
-                                rotation = <90>;
-                                dc-gpios = <&gpio 25 0>;
-                        };
+				spi-max-frequency = <32000000>;
+				rotate = <90>;
+				fps = <25>;
+				bgr;
+				buswidth = <8>;
+				dc-gpios = <&gpio 25 0>;
+				debug = <0>;
+			};
 
-                };
-        };
+		};
+	};
 
-        __overrides__ {
-                speed =   <&pitft>,"spi-max-frequency:0";
-                rotate =  <&pitft>,"rotation:0";
-        };
+	__overrides__ {
+		speed =   <&pitft>,"spi-max-frequency:0";
+		rotate =  <&pitft>,"rotate:0", /* fbtft */
+				<&pitft>,"rotation:0"; /* drm */
+		fps =     <&pitft>,"fps:0";
+		debug =   <&pitft>,"debug:0";
+		drm =     <&pitft>,"compatible=adafruit,yx240qv29";
+	};
 };

--- a/overlays/pitft28-capacitive-overlay.dts
+++ b/overlays/pitft28-capacitive-overlay.dts
@@ -7,79 +7,87 @@
 /plugin/;
 
 / {
-        compatible = "brcm,bcm2835";
+	compatible = "brcm,bcm2835";
 
-        fragment@0 {
-                target = <&spi0>;
-                __overlay__ {
-                        status = "okay";
-                };
-        };
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
 
-        fragment@1 {
-            target = <&spidev0>;
-            __overlay__ {
-                status = "disabled";
-            };
-        };
+	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
 
-        fragment@2 {
-                target = <&gpio>;
-                __overlay__ {
-                        pitft_pins: pitft_pins {
-                                brcm,pins = <24 25>;
-                                brcm,function = <0 1>; /* in out */
-                                brcm,pull = <2 0>; /* pullup none */
-                        };
-                };
-        };
+	fragment@2 {
+		target = <&gpio>;
+		__overlay__ {
+			pitft_pins: pitft_pins {
+				brcm,pins = <24 25>;
+				brcm,function = <0 1>; /* in out */
+				brcm,pull = <2 0>; /* pullup none */
+			};
+		};
+	};
 
-        fragment@3 {
-                target = <&spi0>;
-                __overlay__ {
-                        /* needed to avoid dtc warning */
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+	fragment@3 {
+		target = <&spi0>;
+		__overlay__ {
+			/* needed to avoid dtc warning */
+			#address-cells = <1>;
+			#size-cells = <0>;
 
-                        pitft: pitft@0{
-                                compatible = "adafruit,yx240qv29";
-                                reg = <0>;
-                                pinctrl-names = "default";
-                                pinctrl-0 = <&pitft_pins>;
+			pitft: pitft@0{
+				compatible = "ilitek,ili9340";
+				reg = <0>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&pitft_pins>;
 
-                                spi-max-frequency = <32000000>;
-                                rotation = <90>;
-                                dc-gpios = <&gpio 25 0>;
-                        };
-                };
-        };
+				spi-max-frequency = <32000000>;
+				rotate = <90>;
+				fps = <25>;
+				bgr;
+				buswidth = <8>;
+				dc-gpios = <&gpio 25 0>;
+				debug = <0>;
+			};
+		};
+	};
 
-        fragment@4 {
-                target = <&i2c1>;
-                __overlay__ {
-                        /* needed to avoid dtc warning */
-                        #address-cells = <1>;
-                        #size-cells = <0>;
+	fragment@4 {
+		target = <&i2c1>;
+		__overlay__ {
+			/* needed to avoid dtc warning */
+			#address-cells = <1>;
+			#size-cells = <0>;
 
-                        ft6236: ft6236@38 {
-                                compatible = "focaltech,ft6236";
-                                reg = <0x38>;
+			ft6236: ft6236@38 {
+				compatible = "focaltech,ft6236";
+				reg = <0x38>;
 
-                                interrupt-parent = <&gpio>;
-                                interrupts = <24 2>;
-                                touchscreen-size-x = <240>;
-                                touchscreen-size-y = <320>;
-                        };
-                };
-        };
+				interrupt-parent = <&gpio>;
+				interrupts = <24 2>;
+				touchscreen-size-x = <240>;
+				touchscreen-size-y = <320>;
+			};
+		};
+	};
 
-        __overrides__ {
-                speed =   <&pitft>,"spi-max-frequency:0";
-                rotate =  <&pitft>,"rotation:0";
-                touch-sizex = <&ft6236>,"touchscreen-size-x?";
-                touch-sizey = <&ft6236>,"touchscreen-size-y?";
-                touch-invx  = <&ft6236>,"touchscreen-inverted-x?";
-                touch-invy  = <&ft6236>,"touchscreen-inverted-y?";
-                touch-swapxy = <&ft6236>,"touchscreen-swapped-x-y?";
-        };
+	__overrides__ {
+		speed =   <&pitft>,"spi-max-frequency:0";
+		rotate =  <&pitft>,"rotate:0", /* fbtft */
+				<&pitft>,"rotation:0"; /* drm */
+		fps =     <&pitft>,"fps:0";
+		debug =   <&pitft>,"debug:0";
+		drm =     <&pitft>,"compatible=adafruit,yx240qv29";
+		touch-sizex = <&ft6236>,"touchscreen-size-x:0";
+		touch-sizey = <&ft6236>,"touchscreen-size-y:0";
+		touch-invx  = <&ft6236>,"touchscreen-inverted-x?";
+		touch-invy  = <&ft6236>,"touchscreen-inverted-y?";
+		touch-swapxy = <&ft6236>,"touchscreen-swapped-x-y?";
+	};
 };

--- a/overlays/pitft28-resistive-overlay.dts
+++ b/overlays/pitft28-resistive-overlay.dts
@@ -1,0 +1,126 @@
+/*
+ * Device Tree overlay for Adafruit PiTFT 2.8" resistive touch screen
+ *
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@3 {
+		target = <&gpio>;
+		__overlay__ {
+			pitft_pins: pitft_pins {
+				brcm,pins = <24 25>;
+				brcm,function = <0 1>; /* in out */
+				brcm,pull = <2 0>; /* pullup none */
+			};
+		};
+	};
+
+	fragment@4 {
+		target = <&spi0>;
+		__overlay__ {
+			/* needed to avoid dtc warning */
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			pitft: pitft@0{
+				compatible = "ilitek,ili9340";
+				reg = <0>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&pitft_pins>;
+
+				spi-max-frequency = <32000000>;
+				rotate = <90>;
+				fps = <25>;
+				bgr;
+				buswidth = <8>;
+				dc-gpios = <&gpio 25 0>;
+				debug = <0>;
+			};
+
+			pitft_ts@1 {
+				/* needed to avoid dtc warning */
+				#address-cells = <1>;
+				#interrupt-cells = <1>;
+				compatible = "st,stmpe610";
+				reg = <1>;
+
+				spi-max-frequency = <500000>;
+				interrupts = <24 2>; /* high-to-low edge triggered */
+				interrupt-parent = <&gpio>;
+				interrupt-controller;
+
+				stmpe_touchscreen: stmpe_touchscreen {
+					compatible = "st,stmpe-ts";
+					st,sample-time = <4>;
+					st,mod-12b = <1>;
+					st,ref-sel = <0>;
+					st,adc-freq = <2>;
+					st,ave-ctrl = <3>;
+					st,touch-det-delay = <4>;
+					st,settling = <2>;
+					st,fraction-z = <7>;
+					st,i-drive = <0>;
+				};
+
+				stmpe_gpio: stmpe_gpio {
+					#gpio-cells = <2>;
+					compatible = "st,stmpe-gpio";
+					/*
+					 * only GPIO2 is wired/available
+					 * and it is wired to the backlight
+					 */
+					st,norequest-mask = <0x7b>;
+				};
+			};
+		};
+	};
+
+	fragment@5 {
+		target-path = "/soc";
+		__overlay__ {
+			backlight {
+				compatible = "gpio-backlight";
+				gpios = <&stmpe_gpio 2 0>;
+				default-on;
+			};
+		};
+	};
+
+	__overrides__ {
+		speed =   <&pitft>,"spi-max-frequency:0";
+		rotate =  <&pitft>,"rotate:0", /* fbtft */
+			  <&pitft>,"rotation:0"; /* drm */
+		fps =     <&pitft>,"fps:0";
+		debug =   <&pitft>,"debug:0";
+		drm =     <&pitft>,"compatible=adafruit,yx240qv29";
+		touch-invx  = <&stmpe_touchscreen>,"touchscreen-inverted-x?";
+		touch-invy  = <&stmpe_touchscreen>,"touchscreen-inverted-y?";
+		touch-swapxy = <&stmpe_touchscreen>,"touchscreen-swapped-x-y?";
+	};
+};

--- a/overlays/pitft35-resistive-overlay.dts
+++ b/overlays/pitft35-resistive-overlay.dts
@@ -1,0 +1,127 @@
+/*
+ * Device Tree overlay for Adafruit PiTFT 3.5" resistive touch screen
+ *
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target = <&spi0>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev0>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target = <&spidev1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@3 {
+		target = <&gpio>;
+		__overlay__ {
+			pitft_pins: pitft_pins {
+				brcm,pins = <24 25>;
+				brcm,function = <0 1>; /* in out */
+				brcm,pull = <2 0>; /* pullup none */
+			};
+		};
+	};
+
+	fragment@4 {
+		target = <&spi0>;
+		__overlay__ {
+			/* needed to avoid dtc warning */
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			pitft: pitft@0{
+				compatible = "himax,hx8357d";
+				reg = <0>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&pitft_pins>;
+
+				spi-max-frequency = <32000000>;
+				rotate = <90>;
+				fps = <25>;
+				bgr;
+				buswidth = <8>;
+				dc-gpios = <&gpio 25 0>;
+				debug = <0>;
+			};
+
+			pitft_ts@1 {
+				/* needed to avoid dtc warning */
+				#address-cells = <1>;
+				#interrupt-cells = <1>;
+				compatible = "st,stmpe610";
+				reg = <1>;
+
+				spi-max-frequency = <500000>;
+				interrupts = <24 2>; /* high-to-low edge triggered */
+				interrupt-parent = <&gpio>;
+				interrupt-controller;
+
+				stmpe_touchscreen: stmpe_touchscreen {
+					compatible = "st,stmpe-ts";
+					st,sample-time = <4>;
+					st,mod-12b = <1>;
+					st,ref-sel = <0>;
+					st,adc-freq = <2>;
+					st,ave-ctrl = <3>;
+					st,touch-det-delay = <4>;
+					st,settling = <2>;
+					st,fraction-z = <7>;
+					st,i-drive = <0>;
+				};
+
+				stmpe_gpio: stmpe_gpio {
+					#gpio-cells = <2>;
+					compatible = "st,stmpe-gpio";
+					/*
+					 * only GPIO2 is wired/available
+					 * and it is wired to the backlight
+					 */
+					st,norequest-mask = <0x7b>;
+				};
+			};
+		};
+	};
+
+	fragment@5 {
+		target-path = "/soc";
+		__overlay__ {
+			backlight: backlight {
+				compatible = "gpio-backlight";
+				gpios = <&stmpe_gpio 2 0>;
+				default-on;
+			};
+		};
+	};
+
+	__overrides__ {
+		speed =   <&pitft>,"spi-max-frequency:0";
+		rotate =  <&pitft>,"rotate:0", /* fbtft */
+			  <&pitft>,"rotation:0"; /* drm */
+		fps =     <&pitft>,"fps:0";
+		debug =   <&pitft>,"debug:0";
+		drm =     <&pitft>,"compatible=adafruit,yx350hv15",
+			  <&pitft>,"backlight:0=",<&backlight>;
+		touch-invx  = <&stmpe_touchscreen>,"touchscreen-inverted-x?";
+		touch-invy  = <&stmpe_touchscreen>,"touchscreen-inverted-y?";
+		touch-swapxy = <&stmpe_touchscreen>,"touchscreen-swapped-x-y?";
+	};
+};


### PR DESCRIPTION
These are the overlays updated in https://github.com/raspberrypi/linux/pull/5903. Since the overlays can handle both the drm and non-drm drivers, the script has been updated to reflect those.

cc: @ladyada for review