### PR TITLE
drm added for PiTFT 3.5" resistive

### DIFF
--- a/adafruit-pitft.py
+++ b/adafruit-pitft.py
@@ -118,7 +118,7 @@ config = [
                 "270": "touch-swapxy,touch-invy",
             },
         },
-        "overlay": "dtoverlay=pitft35-resistive,rotate={pitftrot},speed=20000000,fps=20",
+        "overlay": "dtoverlay=pitft35-resistive,rotate={pitftrot},speed=20000000,fps=20,drm",
 	    "overlay_drm_option": "drm",
         "force_x11": True,
         "calibrations": {

--- a/adafruit-pitft.py
+++ b/adafruit-pitft.py
@@ -118,7 +118,7 @@ config = [
                 "270": "touch-swapxy,touch-invy",
             },
         },
-        "overlay": "dtoverlay=pitft35-resistive,rotate={pitftrot},speed=20000000,fps=20,drm",
+        "overlay": "dtoverlay=pitft35-resistive,rotate={pitftrot},speed=20000000,fps=20",
 	    "overlay_drm_option": "drm",
         "force_x11": True,
         "calibrations": {
@@ -902,7 +902,7 @@ restart the script and choose a different orientation.""".format(rotation=pitftr
             shell.bail("Unable to install display drivers")
 
     shell.info(f"Updating {boot_dir}/config.txt...")
-    if not update_configtxt(tinydrm_install=wayland):
+    if not update_configtxt(tinydrm_install=(not is_bullseye)):
         shell.bail(f"Unable to update {boot_dir}/config.txt")
 
     if "touchscreen" in pitft_config:


### PR DESCRIPTION
The PiTFT 3.5" resistive display requires a drm flag to work with Pi Zero and 3B versions of Bookworm. Tested on Pi4 and Pi5 as well.