### PR TITLE
pi5 GPIO packages fix

### DIFF
--- a/raspi-blinka.py
+++ b/raspi-blinka.py
@@ -95,6 +95,15 @@ def install_blinka(user=False):
     shell.run_command(f"{pip_command} RPi.GPIO", run_as_user=username)
     shell.run_command(f"{pip_command} adafruit-blinka", run_as_user=username)
 
+# Custom function to run additional commands for Pi 5
+def check_and_install_for_pi5(pi_model):
+    if pi_model.startswith("RASPBERRY_PI_5"):
+        print("Detected Raspberry Pi 5, applying additional fixes...")
+        os.system("sudo apt remove python3-rpi.gpio")
+        os.system("pip3 install rpi-lgpio")
+    else:
+        print(f"Detected {pi_model}, no additional fixes needed.")
+
 def main():
     global default_python
     shell.clear()
@@ -129,6 +138,9 @@ Raspberry Pi and installs Blinka
     update_python()
     update_pip()
     install_blinka(True)
+
+    # Check and install for Pi 5 if detected
+    check_and_install_for_pi5(pi_model)
 
     # Done
     print("""DONE.


### PR DESCRIPTION
Necessary for blinkatest.py to run without errors on a Pi 5.

Adds two shell commands for pi5 only. 

```
sudo apt remove python3-rpi.gpio
pip3 install rpi-lgpio
```

Tested on a Pi4 and Pi5 running Bookworm 64-bit Lite. 

Both run clean blinkatest.py after. 

You can see the script logic at the end.

```
Detected RASPBERRY_PI_4B, no additional fixes needed.
```

```
Detected Raspberry Pi 5, applying additional fixes...
```


