### PR TITLE
Fix enable and disable of Wayland.

### DIFF
--- a/adafruit-pitft.py
+++ b/adafruit-pitft.py
@@ -741,11 +741,11 @@ def disable_wayland(disable):
         return
     if disable:
         print("Using X11 instead of Wayland")
-        if not shell.run_command("sudo raspi-config nonint do_wayland W1"):
+        if not shell.run_command("sudo raspi-config nonint do_wayland 0"):
             shell.bail("Unable to disable Wayland")
     else:
         print("Using Wayland instead of X11")
-        if not shell.run_command("sudo raspi-config nonint do_wayland W1"):
+        if not shell.run_command("sudo raspi-config nonint do_wayland 1"):
             shell.bail("Unable to enable Wayland")
 
 ####################################################### MAIN


### PR DESCRIPTION
raspi-config was being called with W1 as enable / disable parameter instead of 0 / 1 .