### PR TITLE
Update blinka installer to handle unsupported Pis

### DIFF
--- a/raspi-blinka.py
+++ b/raspi-blinka.py
@@ -112,6 +112,8 @@ def main():
     shell.clear()
     # Check Raspberry Pi and Bail
     pi_model = shell.get_board_model()
+    if not pi_model:
+        shell.bail("This model of Raspberry Pi is not currently supported by Blinka")
     print("""This script configures your
 Raspberry Pi and installs Blinka
 """)


### PR DESCRIPTION
When adding the Pi500, I noticed it choked because it hadn't been added to platformdetect yet. This give an appropriate message now in that case.

cc @ladyada  for review.