### PR TITLE
bookworm update effects adafruit-pitft.py

### DIFF
--- a/adafruit-pitft.py
+++ b/adafruit-pitft.py
@@ -741,11 +741,11 @@ def disable_wayland(disable):
         return
     if disable:
         print("Using X11 instead of Wayland")
-        if not shell.run_command("sudo raspi-config nonint do_wayland 0"):
+        if not shell.run_command("sudo raspi-config nonint do_wayland W1"):
             shell.bail("Unable to disable Wayland")
     else:
         print("Using Wayland instead of X11")
-        if not shell.run_command("sudo raspi-config nonint do_wayland 1"):
+        if not shell.run_command("sudo raspi-config nonint do_wayland W2"):
             shell.bail("Unable to enable Wayland")
 
 ####################################################### MAIN


### PR DESCRIPTION
Minor argument change to rapsi-config do_wayland setting. 

This is in regards to [issue# 331](https://github.com/adafruit/Raspberry-Pi-Installer-Scripts/issues/331) which is "Programmer error, unrecognized boot option" error message from adafruit-pitft.py since a January 2025 package update. raspi-config expect different arguments for do_wayland of W1, W2 and W3. I confirmed that all three work with a Pi 4B and 3.5" TFT.