### PR TITLE
Update RGB Matrix Installer

### DIFF
--- a/rgb-matrix.sh
+++ b/rgb-matrix.sh
@@ -308,12 +308,17 @@ if [ $INSTALL_RTC -ne 0 ]; then
 fi
 
 if [ $QUALITY_MOD -eq 0 ]; then
-	# Disable sound ('easy way' -- kernel module not blacklisted)
+	# Disable sound
 	reconfig $CONFIG_FILE "^.*dtparam=audio.*$" "dtparam=audio=off"
+	# The rgb-matrix software also checks for the module to be blacklisted.
+	echo "blacklist snd_bcm2835" | sudo tee /etc/modprobe.d/blacklist-rgb-matrix.conf > /dev/null
 else
-	# Enable sound (ditto)
+	# Enable sound
 	reconfig $CONFIG_FILE "^.*dtparam=audio.*$" "dtparam=audio=on"
+	# Remove kernel blacklist if present
+	sudo rm -f /etc/modprobe.d/blacklist-rgb-matrix.conf
 fi
+sudo update-initramfs -u
 
 if [ $ISOL_CPU -eq 1 ]; then
 	# Enable CPU core isolation

--- a/rgb-matrix.sh
+++ b/rgb-matrix.sh
@@ -21,6 +21,13 @@ fi
 HAS_PYTHON2=$( [ ! $(which python2) ] ; echo $?)
 HAS_PYTHON3=$( [ ! $(which python3) ] ; echo $?)
 
+# Bookworm moved the config file from /boot/config.txt to /boot/firmware/config.txt
+# Check to see where it is to ensure the config changes are written to the right place.
+CONFIG_FILE=/boot/firmware/config.txt
+if [ ! -f $CONFIG_FILE ]; then
+    CONFIG_FILE=/boot/config.txt
+fi
+
 clear
 
 echo "This script installs software for the Adafruit"
@@ -267,7 +274,7 @@ if [ $INSTALL_RTC -ne 0 ]; then
 	# Enable I2C for RTC
 	raspi-config nonint do_i2c 0
 	# Do additional RTC setup for DS1307
-	reconfig /boot/config.txt "^.*dtoverlay=i2c-rtc.*$" "dtoverlay=i2c-rtc,ds1307"
+	reconfig $CONFIG_FILE "^.*dtoverlay=i2c-rtc.*$" "dtoverlay=i2c-rtc,ds1307"
 	apt-get -y remove fake-hwclock
 	update-rc.d -f fake-hwclock remove
 	sudo sed --in-place '/if \[ -e \/run\/systemd\/system \] ; then/,+2 s/^#*/#/' /lib/udev/hwclock-set
@@ -276,10 +283,10 @@ fi
 
 if [ $QUALITY_MOD -eq 0 ]; then
 	# Disable sound ('easy way' -- kernel module not blacklisted)
-	reconfig /boot/config.txt "^.*dtparam=audio.*$" "dtparam=audio=off"
+	reconfig $CONFIG_FILE "^.*dtparam=audio.*$" "dtparam=audio=off"
 else
 	# Enable sound (ditto)
-	reconfig /boot/config.txt "^.*dtparam=audio.*$" "dtparam=audio=on"
+	reconfig $CONFIG_FILE "^.*dtparam=audio.*$" "dtparam=audio=on"
 fi
 
 # PROMPT FOR REBOOT --------------------------------------------------------

--- a/rgb-matrix.sh
+++ b/rgb-matrix.sh
@@ -216,10 +216,10 @@ echo "Updating package index files..."
 apt-get update
 
 echo "Downloading prerequisites..."
-if [ $HAS_PYTHON2 ]; then
+if [ "$HAS_PYTHON2" = 1 ]; then
 	apt-get install -y --force-yes python2.7-dev python-pillow
 fi
-if [ $HAS_PYTHON3 ]; then
+if [ "$HAS_PYTHON3" = 1 ]; then
 	apt-get install -y --force-yes python3-dev python3-pillow
 fi
 
@@ -239,24 +239,24 @@ USER_DEFINES=""
 #	USER_DEFINES+=" -DLED_ROWS=${MATRIX_HEIGHTS[$MATRIX_SIZE]}"
 #fi
 if [ $QUALITY_MOD -eq 0 ]; then
-	if [ $HAS_PYTHON2 ]; then
+	if [ "$HAS_PYTHON2" = 1 ]; then
 		# Build and install for Python 2.7...
 		make clean
 		make install-python HARDWARE_DESC=adafruit-hat-pwm USER_DEFINES="$USER_DEFINES" PYTHON=$(which python2)
 	fi
-	if [ $HAS_PYTHON3 ]; then
+	if [ "$HAS_PYTHON3" = 1 ]; then
 		# Do over for Python 3...
 		make clean
 		make install-python HARDWARE_DESC=adafruit-hat-pwm USER_DEFINES="$USER_DEFINES" PYTHON=$(which python3)
 	fi
 else
 	USER_DEFINES+=" -DDISABLE_HARDWARE_PULSES"
-	if [ $HAS_PYTHON2 ]; then
+	if [ "$HAS_PYTHON2" = 1 ]; then
 		# Build then install for Python 2.7...
 		make clean
 		make install-python HARDWARE_DESC=adafruit-hat USER_DEFINES="$USER_DEFINES" PYTHON=$(which python2)
 	fi
-	if [ $HAS_PYTHON3 ]; then
+	if [ "$HAS_PYTHON3" = 1 ]; then
 		# Do over for Python 3...
 		make clean
 		make install-python HARDWARE_DESC=adafruit-hat USER_DEFINES="$USER_DEFINES" PYTHON=$(which python3)

--- a/rgb-matrix.sh
+++ b/rgb-matrix.sh
@@ -217,10 +217,10 @@ apt-get update
 
 echo "Downloading prerequisites..."
 if [ "$HAS_PYTHON2" = 1 ]; then
-	apt-get install -y --force-yes python2.7-dev python-pillow
+	apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages python2.7-dev python-pillow
 fi
 if [ "$HAS_PYTHON3" = 1 ]; then
-	apt-get install -y --force-yes python3-dev python3-pillow
+	apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages python3-dev python3-pillow
 fi
 
 echo "Downloading RGB matrix software..."

--- a/rgb-matrix.sh
+++ b/rgb-matrix.sh
@@ -7,8 +7,8 @@
 # we reference a specific commit (update this as needed):
 GITUSER=https://github.com/hzeller
 REPO=rpi-rgb-led-matrix
-COMMIT=21410d2b0bac006b4a1661594926af347b3ce334
-# Previously: COMMIT=e3dd56dcc0408862f39cccc47c1d9dea1b0fb2d2 
+COMMIT=84e1465e9ea5ed000011d05369c5287eaa361ad7
+# Previously: COMMIT=21410d2b0bac006b4a1661594926af347b3ce334
 
 if [ $(id -u) -ne 0 ]; then
 	echo "Installer must be run as root."

--- a/rgb-matrix.sh
+++ b/rgb-matrix.sh
@@ -7,7 +7,8 @@
 # we reference a specific commit (update this as needed):
 GITUSER=https://github.com/hzeller
 REPO=rpi-rgb-led-matrix
-COMMIT=a3eea997a9254b83ab2de97ae80d83588f696387
+COMMIT=62986e65dec25451a37531896be087664a49929b
+# Previously: COMMIT=a3eea997a9254b83ab2de97ae80d83588f696387
 # Previously: COMMIT=45d3ab5d6cff6e0c14da58930d662822627471fc
 # Previously: COMMIT=21410d2b0bac006b4a1661594926af347b3ce334
 # Previously: COMMIT=e3dd56dcc0408862f39cccc47c1d9dea1b0fb2d2 


### PR DESCRIPTION
This PR makes the following improvements/updates to the RGB Matrix Installer:
* Fixes the config.txt modifications to occur at the right place on bookworm builds (see https://github.com/RPi-Distro/raspberrypi-sys-mods/issues/88)
* Fixes python version checking that didn't actually appear to function correctly
* updates deprecated apt-get arguments to their modern equivalents
* Adds a setup option to automatically configure CPU core isolation on mutli-core Pis, per the recommendation from the RGB matrix repo maintainers
* Fully blacklists the kernel sound module instead of just changing the config.txt setting. This prevents complaints from the RGB matrix library on launch.
* Updates to the latest commit of the RGB matrix library, which I have tested and confirmed working on an Adafruit matrix+RTC hat.