### PR TITLE
adafruit-pitft.py boot_dir

### DIFF
--- a/adafruit-pitft.py
+++ b/adafruit-pitft.py
@@ -743,8 +743,14 @@ user_homedir = os.path.expanduser(f"~{username}")
 if shell.isdir(user_homedir):
     target_homedir = user_homedir
 
-boot_dir = shell.get_boot_config()
-if boot_dir is None:
+boot_dir = "/boot/firmware" if shell.isdir("/boot/firmware") else "/boot"
+
+# If neither directory is valid, use shell.get_boot_config()
+if not shell.isdir(boot_dir):
+    boot_dir = shell.get_boot_config()
+
+# Final safeguard: Ensure boot_dir is actually a directory and not a file path
+if boot_dir is None or not shell.isdir(boot_dir):
     shell.bail("Unable to find boot directory")
 
 if shell.get_raspbian_version() == "bullseye":


### PR DESCRIPTION
fix for  /boot/firmware vs /boot logic for the config.txt location

A recent change to adafruit-pitft.py is causing this error message on Pi OS Bookworm systems Pi3B and Pi4B confirmed. Likely all models are effected when setting up a TFT display on Bookworm.

```
PITFT Updating /boot/firmware/config.txt/config.txt...
Traceback (most recent call last):
  File "/home/pi/Raspberry-Pi-Installer-Scripts/adafruit-pitft.py", line 944, in <module>
    main()
  File "/home/pi/env/lib/python3.11/site-packages/click/core.py", line 1161, in __call__                                                                                    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/env/lib/python3.11/site-packages/click/core.py", line 1082, in main    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/pi/env/lib/python3.11/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/env/lib/python3.11/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/Raspberry-Pi-Installer-Scripts/adafruit-pitft.py", line 892, in main
    if not update_configtxt(tinydrm_install=(not is_bullseye)):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/Raspberry-Pi-Installer-Scripts/adafruit-pitft.py", line 431, in update_configtxt
    shell.write_text_file(f"{boot_dir}/config.txt", """
  File "/home/pi/env/lib/python3.11/site-packages/adafruit_shell.py", line 475, in write_text_file
    with open(self.path(path), mode, encoding="utf-8") as service_file:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
NotADirectoryError: [Errno 20] Not a directory: '/boot/firmware/config.txt/config.txt'
```

Easy work around is to hand specify boot_dir:

```
--boot=/boot/firmware
```

```
 sudo -E env PATH=$PATH python3 adafruit-pitft.py --display=28c --rotation=90 --install-type=console  --boot=/boot/firmware
 ```

This code just puts in some safety checks and does not rely on shell.get_boot_config() which was problematic. Tested and confirmed to work on Bookworm, 64-bit, Lite, Pi 4B, 2.8c display.

[Forum issue](https://forums.adafruit.com/viewtopic.php?t=217144) for reference.

