### PR TITLE
Fix expected get_boot_config to return folder

### DIFF
--- a/adafruit-pitft.py
+++ b/adafruit-pitft.py
@@ -747,7 +747,7 @@ boot_dir = "/boot/firmware" if shell.isdir("/boot/firmware") else "/boot"
 
 # If neither directory is valid, use shell.get_boot_config()
 if not shell.isdir(boot_dir):
-    boot_dir = shell.get_boot_config()
+    boot_dir = os.path.dirname(shell.get_boot_config())
 
 # Final safeguard: Ensure boot_dir is actually a directory and not a file path
 if boot_dir is None or not shell.isdir(boot_dir):


### PR DESCRIPTION
I found this in guide feedback. Looking at the code, the script was expecting to get a link to the folder rather than the file, so this is now fixed.

cc: @ladyada for review