### PR TITLE
Updated i2smic.py for supporting CM3 Plus module

### DIFF
--- a/i2smic.py
+++ b/i2smic.py
@@ -19,7 +19,7 @@ I2S microphone support.
     print("{} detected.\n".format(pi_model))
     if pi_model in ("RASPBERRY_PI_ZERO", "RASPBERRY_PI_ZERO_W", "RASPBERRY_PI_B_REV2"):
         pimodel_select = 0
-    elif pi_model in ("RASPBERRY_PI_2B", "RASPBERRY_PI_3B", "RASPBERRY_PI_3B_PLUS", "RASPBERRY_PI_3A_PLUS", "RASPBERRY_PI_ZERO_2_W"):
+    elif pi_model in ("RASPBERRY_PI_2B", "RASPBERRY_PI_3B", "RASPBERRY_PI_CM3_PLUS", "RASPBERRY_PI_3B_PLUS", "RASPBERRY_PI_3A_PLUS", "RASPBERRY_PI_ZERO_2_W"):
         pimodel_select = 1
     elif pi_model in ("RASPBERRY_PI_4B", "RASPBERRY_PI_CM4", "RASPBERRY_PI_400"):
         pimodel_select = 2


### PR DESCRIPTION
This PR fixes the installer setup for supporting I2S mic installation on the CM3+ module. Essentially, the steps were taken from this guide:
https://makersportal.com/blog/recording-stereo-audio-on-a-raspberry-pi