### PR TITLE
adafruit-pitft.py : remove console drm

### DIFF
--- a/adafruit-pitft.py
+++ b/adafruit-pitft.py
@@ -1007,7 +1007,8 @@ restart the script and choose a different orientation.""".format(rotation=pitftr
             shell.bail("Unable to install display drivers")
 
     shell.info(f"Updating {boot_dir}/config.txt...")
-    if not update_configtxt(tinydrm_install=True):
+    use_tinydrm = install_type != "console"
+    if not update_configtxt(tinydrm_install=use_tinydrm):
         shell.bail(f"Unable to update {boot_dir}/config.txt")
 
     if "touchscreen" in pitft_config:


### PR DESCRIPTION
There is a drm flag being appended to the config.txt that does not play well with older Pi Zero, Pi Zero 2W and Pi 3B+ models in console mode. It results in a blank screen.

`
dtoverlay=pitft28-capacitive,rotate=90,speed=64000000,fps=30,drm
`

Removing the final drm argument when using console mode only will allow all Pi's to have a working login shell. The one downside is when we turn off DRM the display is flipped so the guide needs to change rotation from 90 to 270. The above config.txt line would look like this. [Learn guide update required](https://learn.adafruit.com/adafruit-pitft-28-inch-resistive-touchscreen-display-raspberry-pi/easy-install-2#console-mode-install-commands-3074228) to match this PR.

`
dtoverlay=pitft28-capacitive,rotate=270,speed=64000000,fps=30
`

Tested on various Pi's with both Trixie Desktop and Lite 64-bit installs. After patch all Pi's should use 270 rotation, no drm for console mode only. 

```
+------------+----------+-------------------+
| Pi Model   | Rotation | DRM (config.txt)  |
+------------+----------+-------------------+
| Pi Zero 2W |      270 | must remove       |
| Pi 3B+     |      270 | must remove       |
| Pi 4B      |       90 | Works             |
| Pi 5       |       90 | Works             |
+------------+----------+-------------------+
```

[forum issue](https://forums.adafruit.com/viewtopic.php?t=221607)
