### PR TITLE
Replace lgpio build-from-source with apt install in raspi-blinka.py

### DIFF
--- a/raspi-blinka.py
+++ b/raspi-blinka.py
@@ -103,18 +103,7 @@ def check_and_install_for_pi5(pi_model, user=False):
         print("Detected Raspberry Pi 5, applying additional fixes...")
         if shell.exists("lg"):
             shell.remove("lg")
-        shell.run_command("sudo apt-get install -y wget swig python3-dev python3-setuptools")
-        # Temporarily install setuptools to as root for the build process
-        shell.run_command("sudo pip3 install -U setuptools", run_as_user=username)
-        shell.run_command("wget https://github.com/adafruit/Raspberry-Pi-Installer-Scripts/raw/refs/heads/main/packages/lgpio.zip")
-        shell.run_command("unzip lgpio.zip")
-        if shell.exists("lgpio.zip"):
-            shell.remove("lgpio.zip")
-        shell.chdir("lg")
-        shell.run_command("make")
-        shell.run_command("sudo make install")
-        # Remove setuptools after the build process is complete
-        shell.run_command("sudo pip3 uninstall -y setuptools", run_as_user=username)
+        shell.run_command("sudo apt-get install -y python3-lgpio")
     else:
         print(f"Detected {pi_model}, no additional fixes needed.")
 


### PR DESCRIPTION
## Problem

The `check_and_install_for_pi5()` function in `raspi-blinka.py` builds lgpio from source by downloading a zip, running `swig`, `make`, and `make install`. This approach:

- Requires `swig`, `python3-dev`, and `python3-setuptools` as build deps
- Uses `sudo pip3 install/uninstall setuptools` which conflicts with PEP 668 (externally-managed environments) on newer Raspberry Pi OS
- Downloads from GitHub at build time (fragile)
- Is slow and error-prone

## Fix

Replace the entire build-from-source block with:

```python
shell.run_command("sudo apt-get install -y python3-lgpio")
```

The `python3-lgpio` package (version 0.2.2) is available in the official Raspberry Pi OS repos for both `arm64` and `armhf`, maintained by Serge Schneider at Raspberry Pi.

## Before (20 lines)
```
wget → unzip → make → make install (plus setuptools dance)
```

## After (1 line)
```
sudo apt-get install -y python3-lgpio
```

Relates to: adafruit/Adafruit_Blinka#1016