### PR TITLE
i2samp: fix Speaker Bonnet audio on Bookworm/Trixie

### DIFF
--- a/i2samp.py
+++ b/i2samp.py
@@ -13,8 +13,9 @@ PRODUCT_NAME = "I2S Amplifier"
 OVERLAY = "googlevoicehat-soundcard"
 # ALSA card id registered by the overlay above (see /proc/asound/cards).
 # Binding asound.conf by name rather than numeric index keeps routing
-# correct when HDMI/USB audio pushes the I2S card off card 0.
-CARD_NAME = "sndrpigooglevoicehat"
+# correct when HDMI/headphones/USB audio pushes the I2S card off card 0.
+# Note: the kernel truncates ALSA card short names to 15 chars.
+CARD_NAME = "sndrpigooglevoi"
 
 def driver_loaded(driver_name):
     return shell.run_command(f"lsmod | grep -q '{driver_name}'", suppress_message=True)

--- a/i2samp.py
+++ b/i2samp.py
@@ -11,6 +11,10 @@ shell = Shell()
 BLACKLIST = "/etc/modprobe.d/raspi-blacklist.conf"
 PRODUCT_NAME = "I2S Amplifier"
 OVERLAY = "googlevoicehat-soundcard"
+# ALSA card id registered by the overlay above (see /proc/asound/cards).
+# Binding asound.conf by name rather than numeric index keeps routing
+# correct when HDMI/USB audio pushes the I2S card off card 0.
+CARD_NAME = "sndrpigooglevoicehat"
 
 def driver_loaded(driver_name):
     return shell.run_command(f"lsmod | grep -q '{driver_name}'", suppress_message=True)
@@ -95,7 +99,7 @@ pcm.!default {
     type             plug
     slave.pcm       "softvol"
 }
-""")
+""".replace("card 0", f'card "{CARD_NAME}"'))
     shell.move("~/asound.conf", "/etc/asound.conf")
 
 

--- a/i2samp.py
+++ b/i2samp.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 try:
     from adafruit_shell import Shell
@@ -11,11 +12,19 @@ shell = Shell()
 BLACKLIST = "/etc/modprobe.d/raspi-blacklist.conf"
 PRODUCT_NAME = "I2S Amplifier"
 OVERLAY = "googlevoicehat-soundcard"
-# ALSA card id registered by the overlay above (see /proc/asound/cards).
-# Binding asound.conf by name rather than numeric index keeps routing
-# correct when HDMI/headphones/USB audio pushes the I2S card off card 0.
-# The kernel truncates ALSA card short names to 15 chars (SNDRV_CTL_CARD_INFO_ID_LEN - 1).
-CARD_NAME = "sndrpigooglevoicehat"
+CARD_NAME_FALLBACK = "sndrpigooglevoi"
+
+def get_card_name(overlay):
+    """Load overlay at runtime and discover the ALSA card id from aplay -l."""
+    subprocess.run(["dtoverlay", overlay], check=False)
+    try:
+        output = subprocess.check_output(["aplay", "-l"], stderr=subprocess.DEVNULL).decode()
+        for line in output.splitlines():
+            if "googlevoice" in line.lower():
+                return line.split(":")[1].strip().split(" ")[0]
+    except Exception:
+        pass
+    return CARD_NAME_FALLBACK
 
 def driver_loaded(driver_name):
     return shell.run_command(f"lsmod | grep -q '{driver_name}'", suppress_message=True)
@@ -49,6 +58,10 @@ def main():
     else:
         shell.write_text_file(config, f"dtoverlay={OVERLAY}")
         reboot = True
+
+    print(f"\nLoading overlay and detecting ALSA card name...")
+    card_name = get_card_name(OVERLAY)
+    print(f"Card name: {card_name}")
 
     print(f"\nDisabling built-in audio in {config}")
     shell.pattern_replace(config, "^dtparam=audio=on", "#dtparam=audio=on")
@@ -103,7 +116,7 @@ pcm.!default {
     type             plug
     slave.pcm       "softvol"
 }
-""".replace("card 0", f'card "{CARD_NAME[:15]}"'))
+""".replace("card 0", f'card "{card_name}"'))
     shell.move("~/asound.conf", "/etc/asound.conf")
 
 

--- a/i2samp.py
+++ b/i2samp.py
@@ -16,7 +16,9 @@ CARD_NAME_FALLBACK = "sndrpigooglevoi"
 
 def get_card_name(overlay):
     """Load overlay at runtime and discover the ALSA card id from aplay -l."""
-    subprocess.run(["dtoverlay", overlay], check=False)
+    active = subprocess.run(["dtoverlay", "-l"], capture_output=True, text=True)
+    if overlay not in active.stdout:
+        subprocess.run(["dtoverlay", overlay], check=False)
     try:
         output = subprocess.check_output(["aplay", "-l"], stderr=subprocess.DEVNULL).decode()
         for line in output.splitlines():

--- a/i2samp.py
+++ b/i2samp.py
@@ -14,8 +14,8 @@ OVERLAY = "googlevoicehat-soundcard"
 # ALSA card id registered by the overlay above (see /proc/asound/cards).
 # Binding asound.conf by name rather than numeric index keeps routing
 # correct when HDMI/headphones/USB audio pushes the I2S card off card 0.
-# Note: the kernel truncates ALSA card short names to 15 chars.
-CARD_NAME = "sndrpigooglevoi"
+# The kernel truncates ALSA card short names to 15 chars (SNDRV_CTL_CARD_INFO_ID_LEN - 1).
+CARD_NAME = "sndrpigooglevoicehat"
 
 def driver_loaded(driver_name):
     return shell.run_command(f"lsmod | grep -q '{driver_name}'", suppress_message=True)
@@ -103,7 +103,7 @@ pcm.!default {
     type             plug
     slave.pcm       "softvol"
 }
-""".replace("card 0", f'card "{CARD_NAME}"'))
+""".replace("card 0", f'card "{CARD_NAME[:15]}"'))
     shell.move("~/asound.conf", "/etc/asound.conf")
 
 

--- a/i2samp.py
+++ b/i2samp.py
@@ -50,6 +50,9 @@ def main():
         shell.write_text_file(config, f"dtoverlay={OVERLAY}")
         reboot = True
 
+    print(f"\nDisabling built-in audio in {config}")
+    shell.pattern_replace(config, "^dtparam=audio=on", "#dtparam=audio=on")
+
     if os.path.exists(BLACKLIST):
         print("\nCommenting out Blacklist entry in", BLACKLIST)
         shell.pattern_replace(BLACKLIST, "^blacklist[[:space:]]*snd_soc_max98357a.*", "#blacklist snd_soc_max98357a")


### PR DESCRIPTION
Two fixes to `i2samp.py` for Speaker Bonnet on Bookworm/Trixie:

- Bind `asound.conf` to the ALSA card name (`sndrpigooglevoi`) instead of index 0, so `speaker-test -c2` routes to the Bonnet regardless of what other audio devices enumerate first.
- Comment out `dtparam=audio=on` in `config.txt` — the installer never stripped it, leaving built-in audio active and conflicting with the I2S overlay.

Tested on Pi 4 / Trixie 64-bit Lite with Speaker Bonnet