### PR TITLE
rgb-matrix.sh: fix Python bindings build on Trixie

### DIFF
--- a/rgb-matrix.sh
+++ b/rgb-matrix.sh
@@ -218,7 +218,7 @@ echo "Updating package index files..."
 apt-get update
 
 echo "Downloading prerequisites..."
-apt-get install -y python3-dev python3-pillow cython3
+apt-get install -y python3-dev python3-pillow cython3 python3-setuptools
 
 echo "Downloading RGB matrix software..."
 curl -L $GITUSER/$REPO/archive/$COMMIT.zip -o $REPO-$COMMIT.zip


### PR DESCRIPTION

Python 3.13, shipped with the **April 2026 Pi OS Trixie release**, removed `distutils` from the stdlib. The RGB matrix Python bindings build via `setup.py`, which imports it — so both `make clean` and `make build-python` fail:

```
ModuleNotFoundError: No module named 'distutils'
```

Fix: add `python3-setuptools` to the prerequisites `apt-get install` line. It provides the distutils compatibility shim. The C demo and all C examples are unaffected — only the Python bindings fail without this.

## Tested on

| Pi | Bonnet | Panel | OS | Python | Status |
|---|---|---|---|---|---|
| Zero 2WH | [RGB Matrix Bonnet (3211)](https://www.adafruit.com/product/3211) | [64×32 2.5mm (5036)](https://www.adafruit.com/product/5036) | Bookworm 64-bit Lite (Legacy) | 3.11 | ✅ works, no change needed |
| Zero 2WH | [RGB Matrix Bonnet (3211)](https://www.adafruit.com/product/3211) | [64×32 2.5mm (5036)](https://www.adafruit.com/product/5036) | Trixie 64-bit Lite (2026-04-21) | 3.13.5 | ✅ fixed by this PR |

[forum issue](https://forums.adafruit.com/viewtopic.php?t=223589)