### PR TITLE
raspi-blinka: add -noupgrade flag to skip system upgrade

### DIFF
--- a/raspi-blinka.py
+++ b/raspi-blinka.py
@@ -50,6 +50,9 @@ def sys_update():
     print("Updating System Packages")
     if not shell.run_command("sudo apt-get update --allow-releaseinfo-change"):
         shell.bail("Apt failed to update indexes!")
+    if shell.argument_exists("noupgrade"):
+        print("Skipping system package upgrade (-noupgrade specified).")
+        return
     print("Upgrading packages...")
     if not shell.run_command("sudo apt-get -y upgrade"):
         shell.bail("Apt failed to install software!")


### PR DESCRIPTION
Adds a `-noupgrade` command-line flag to `raspi-blinka.py` that skips the system package upgrade step while still refreshing apt indexes.

### Why

`sys_update()` currently runs `sudo apt-get -y upgrade` unconditionally before installing Blinka. Two problems:

- On a fresh OS image this can take 10-20 minutes with no per-package feedback, which is a confusing first-run experience.
- On existing systems, `apt-get -y upgrade` accepts all dpkg defaults — which can overwrite user-modified config files without warning.

For users who already upgraded recently, or who don't want a full system upgrade as a side effect of installing a Python library, `-noupgrade` lets them skip just the upgrade step. `apt-get update` still runs so the install steps that follow have a fresh package index.

### Behavior

| Invocation | Behavior |
| --- | --- |
| `sudo python3 raspi-blinka.py` | unchanged — runs `apt-get update` then `apt-get -y upgrade` |
| `sudo python3 raspi-blinka.py -noupgrade` | runs `apt-get update`, skips upgrade, continues with install |

### Notes

- Default behavior is unchanged, so this is non-breaking for existing install guides and `curl | sudo python3` pipelines.
- Flag style matches existing convention in this repo (e.g. `-noautoload`, `-noreboot` in `i2smic.py`).

Closes #178. Thanks to @timonsku for the original report and proposal — this is a smaller, headless-friendly take on the same idea.
