### PR TITLE
Fix PiTFT race condition between vc4-kms-v3d and SPI TFT (#365)

### DIFF
--- a/templates/con2fbmap-helper.sh
+++ b/templates/con2fbmap-helper.sh
@@ -1,25 +1,107 @@
 #!/bin/bash
 
-# Wait for TFT framebuffer to be ready
-echo "Waiting for SPI TFT framebuffer..."
+# Map the Linux console (tty1) to the SPI TFT framebuffer.
+#
+# Background: when vc4-kms-v3d (HDMI) and the SPI TFT DRM driver
+# (ili9341 / hx8357 / mipi-dbi-spi) both load at boot, they race for
+# DRM minor / framebuffer numbers. The SPI display can land on either
+# /dev/fb0 or /dev/fb1 depending on probe order. Greping dmesg for a
+# fixed fb number is brittle (issue #365), so we discover the SPI TFT
+# framebuffer by walking /sys/class/graphics/fb*.
+#
+# After remapping, we force a console refresh so whatever was last
+# drawn on the old framebuffer gets re-rendered on the SPI display.
 
-# Wait up to 30 seconds for /dev/fb0 or /dev/fb1 to appear
-for i in {1..300}; do
-    for fbdev in 0 1; do
-        if [ -e /dev/fb$fbdev ]; then
-            echo "Found /dev/fb$fbdev, checking if it's {display_type}..."
+set -u
 
-            # Check if it's actually the ili9341 device
-            if dmesg | grep -q "{display_type}.*fb$fbdev"; then
-                echo "{display_type} framebuffer ready, mapping console..."
-                con2fbmap 1 $fbdev
-                echo "Console mapped to framebuffer $fbdev"
-                exit 0
-            fi
+DISPLAY_TYPE="{display_type}"
+TIMEOUT_DECISECONDS=300   # 30 seconds (loop sleeps 0.1s)
+
+echo "Waiting for SPI TFT framebuffer (display_type=${DISPLAY_TYPE})..."
+
+# Return 0 (and echo the fb number) if /sys/class/graphics/$1 looks
+# like the SPI TFT we installed for.
+is_spi_tft_fb() {
+    local fbpath="$1"
+    local fbname
+    local devpath
+
+    # Read the framebuffer driver name, e.g. "ili9341drmfb", "hx8357drmfb",
+    # "mipi_dbi", "vc4drmfb", "simple-framebuffer".
+    fbname="$(cat "${fbpath}/name" 2>/dev/null || true)"
+
+    # Resolve the underlying device path (DRM card → parent device).
+    devpath="$(readlink -f "${fbpath}/device" 2>/dev/null || true)"
+
+    # 1) Name-based match. Works for ili9341, hx8357d, st7789, etc. The
+    #    fbdev name varies by driver: DRM tinydrm uses "<name>drmfb"
+    #    (e.g. "ili9341drmfb"); the older fbtft staging driver uses
+    #    "fb_<name>" (e.g. "fb_ili9341"). Accept either.
+    if [ -n "${fbname}" ]; then
+        if [[ "${fbname}" == *"${DISPLAY_TYPE}"* ]]; then
+            return 0
+        fi
+    fi
+
+    # 2) Device-path match. For panel-mipi-dbi-spi the fbdev name is
+    #    "mipi_dbi" which does not contain the configured display_type,
+    #    but the device path under sysfs lives below the SPI controller
+    #    (e.g. .../soc/.../spi@.../spi0.0/...). Match any SPI slave on
+    #    spi0.0, which is where the installer wires SPI TFT panels.
+    if [ -n "${devpath}" ] && [[ "${devpath}" == *"/spi0.0/"* ]]; then
+        # Belt-and-braces: exclude framebuffers that are obviously not
+        # the SPI TFT (e.g. vc4drmfb, simple-framebuffer). Those should
+        # not have spi0.0 in their devpath, but guard anyway.
+        if [[ "${fbname}" != "vc4drmfb" && "${fbname}" != "simple-framebuffer" ]]; then
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+found_fb=""
+
+for ((i = 1; i <= TIMEOUT_DECISECONDS; i++)); do
+    for fbpath in /sys/class/graphics/fb*; do
+        [ -e "${fbpath}" ] || continue
+        fbnum="${fbpath##*/fb}"
+        # Only accept numeric fb entries (skip e.g. /sys/class/graphics/fbcon).
+        case "${fbnum}" in
+            ''|*[!0-9]*) continue ;;
+        esac
+        [ -e "/dev/fb${fbnum}" ] || continue
+
+        if is_spi_tft_fb "${fbpath}"; then
+            found_fb="${fbnum}"
+            break 2
         fi
     done
     sleep 0.1
 done
 
-echo "Timeout waiting for SPI TFT framebuffer"
-exit 1
+if [ -z "${found_fb}" ]; then
+    echo "Timeout waiting for SPI TFT framebuffer (display_type=${DISPLAY_TYPE})"
+    echo "Available framebuffers:"
+    for fbpath in /sys/class/graphics/fb*; do
+        [ -e "${fbpath}/name" ] || continue
+        fbname="$(cat "${fbpath}/name" 2>/dev/null || true)"
+        devpath="$(readlink -f "${fbpath}/device" 2>/dev/null || true)"
+        echo "  ${fbpath}: name='${fbname}' device='${devpath}'"
+    done
+    exit 1
+fi
+
+echo "SPI TFT framebuffer ready on /dev/fb${found_fb}, mapping console..."
+con2fbmap 1 "${found_fb}"
+echo "Console mapped to framebuffer ${found_fb}"
+
+# Force a redraw of tty1. con2fbmap only updates the routing table;
+# without this, getty's earlier output stays on the old framebuffer and
+# the SPI display keeps showing whatever was on it at power-on. ESC c
+# resets the terminal which prompts fbcon to repaint the active console.
+if [ -w /dev/tty1 ]; then
+    printf '\033c' > /dev/tty1 2>/dev/null || true
+fi
+
+exit 0


### PR DESCRIPTION
Fixes the PiTFT race condition reported in #365 where the SPI TFT shows nothing on ~50% of boot cycles.

## What was going wrong

`con2fbmap-helper.sh` discovered the SPI TFT's framebuffer number by greping `dmesg` for a line like `{display_type}.*fb<n>`. That worked when ili9341 won the probe race against `vc4-kms-v3d` and landed on `/dev/fb0`, but failed when vc4 won and ili9341 landed on `/dev/fb1`:

1. **The grep is brittle.** `dmesg` output is buffered/rate-limited, and `ili9341.*fb0` matches any line where those tokens appear in that order, not specifically the fbdev registration message.
2. **`con2fbmap 1 N` doesn't repaint.** It only updates the console→fb routing table. By the time the helper runs at `multi-user.target`, getty has already painted the login prompt to the old fb (vc4's HDMI surface). Nothing writes to tty1 again, so the SPI display stays at whatever was in its panel RAM at power-on — exactly the symptom the reporter described.

## Fix

- Walk `/sys/class/graphics/fb*` and use the authoritative `name` attribute plus the resolved `device` sysfs path to identify the SPI TFT, instead of greping `dmesg`. Numeric fb entries only (so `fbcon` is skipped).
- Match by either:
  - **fb name substring** — covers DRM tinydrm (`ili9341drmfb`, `hx8357drmfb`, etc.) and legacy fbtft staging (`fb_ili9341`, …).
  - **Device path contains `/spi0.0/`** — covers `panel-mipi-dbi-spi` (fb name is just `mipi_dbi`), with `vc4drmfb` and `simple-framebuffer` explicitly excluded as a belt-and-braces guard.
- After `con2fbmap 1 N`, send `ESC c` (terminal reset) to `/dev/tty1` to force fbcon to repaint the active console on the newly-mapped framebuffer. This is the missing piece that makes the display actually show content even when `con2fbmap` resolves the correct fb.
- On timeout, log every framebuffer the helper saw (name + device path) for easier debugging in the future.

## Testing

Smoke-tested the matcher against the cases that matter:

| display_type | fb name | device path | expected | result |
|---|---|---|---|---|
| `ili9341` | `ili9341drmfb` | `.../spi0.0/drm/card0` | match | ✅ |
| `ili9341` | `fb_ili9341` (fbtft) | `.../spi0.0/graphics/fb1` | match | ✅ |
| `hx8357d` | `hx8357drmfb` | `.../spi0.0/drm/card0` | match | ✅ |
| `panel-mipi-dbi-spi` | `mipi_dbi` | `.../spi0.0/drm/card0` | match | ✅ |
| `ili9341` | `vc4drmfb` | `.../3f902000.hdmi/...` | no match | ✅ |
| `ili9341` | `simple-framebuffer` | `.../1eaf0000.framebuffer` | no match | ✅ |

Also confirmed `bash -n` is clean and the timeout/diagnostic-dump path works when no SPI TFT is attached.

Closes #365.
