### PR TITLE
Fix cropped boot console on 32-bit Pi OS with SPI MIPI panels (#341)

### DIFF
--- a/adafruit-pitft.py
+++ b/adafruit-pitft.py
@@ -396,6 +396,26 @@ def uninstall_etc_modules():
     shell.pattern_replace("/etc/modules", 'spi-bcm2835')
     shell.pattern_replace("/etc/modules", 'flexfb')
     shell.pattern_replace("/etc/modules", 'fbtft_device')
+    # Drop any prior pitft early-load list; install_early_modules() will
+    # re-create it for MIPI installs.
+    shell.run_command('rm -f /etc/modules-load.d/pitft.conf')
+    return True
+
+def install_early_modules():
+    """Force-load SPI + DRM MIPI modules at boot.
+
+    On 32-bit Pi OS the panel-mipi-dbi-spi driver can probe 30+ seconds into
+    boot, after getty has already painted to the firmware framebuffer at the
+    wrong resolution. Listing the relevant modules in modules-load.d gets
+    them loaded by systemd-modules-load.service at early userspace so the
+    SPI panel claims fb0 before the console is drawn.
+
+    See: https://github.com/adafruit/Raspberry-Pi-Installer-Scripts/issues/341
+    """
+    if not use_mipi_driver():
+        return True
+    print("Forcing early load of SPI + DRM MIPI panel modules...")
+    shell.write_templated_file("/etc/modules-load.d/", "templates/pitft.conf")
     return True
 
 def use_mipi_driver(config = None):
@@ -483,6 +503,10 @@ def update_configtxt(rotation_override=None, tinydrm_install=False):
         overlay += f"\ndtparam={viewport}"
         if "gpio" in mipi_data:
             overlay += f"\ndtparam={mipi_data['gpio']}"
+        # Disable composite TV-out fb so it cannot interleave with the SPI
+        # panel's framebuffer allocation on 32-bit Pi OS (Pi Zero / Pi 1 /
+        # CM1 default this to 1). See issue #341.
+        overlay += "\nenable_tvout=0"
 
     if tinydrm_install: # Use overlay params for Wayland
         overlay += ",drm"
@@ -1015,6 +1039,11 @@ restart the script and choose a different orientation.""".format(rotation=pitftr
     use_tinydrm = install_type != "console"
     if not update_configtxt(tinydrm_install=use_tinydrm):
         shell.bail(f"Unable to update {boot_dir}/config.txt")
+
+    if use_mipi_driver():
+        shell.info("Configuring early module load for SPI MIPI panel...")
+        if not install_early_modules():
+            shell.bail("Unable to write /etc/modules-load.d/pitft.conf")
 
     if "touchscreen" in pitft_config:
         shell.info("Updating SysFS rules for Touchscreen...")

--- a/templates/pitft.conf
+++ b/templates/pitft.conf
@@ -1,0 +1,10 @@
+# --- added by adafruit-pitft-helper ---
+# Force-load SPI + DRM MIPI panel modules early so the SPI display driver
+# probes before simple-framebuffer is laid out at the wrong resolution.
+# Without this, on 32-bit Pi OS the panel-mipi-dbi-spi driver can load 30+
+# seconds into boot, after getty has already painted to the firmware fb, and
+# the console ends up cropped on the SPI panel. See:
+#   https://github.com/adafruit/Raspberry-Pi-Installer-Scripts/issues/341
+spi_bcm2835
+drm_mipi_dbi
+panel_mipi_dbi


### PR DESCRIPTION
Fixes the cropped/partial console on boot for SPI MIPI panels (e.g. the 1.3" 240x240 ST7789V bonnet) on **32-bit Pi OS**.

## Root cause

On 32-bit Pi OS, the `panel-mipi-dbi-spi` driver doesn't probe until ~30–40 s into boot. The reporter's `dmesg` shows it plainly:

```
[    2.641552] simple-framebuffer 1eaf0000.framebuffer: fb0: simplefb registered!
[   41.538857] panel-mipi-dbi-spi spi0.0: [drm] fb0: panel-mipi-dbid frame buffer device
```

By the time the SPI panel takes over fb0, getty has already drawn the login prompt onto the firmware-provided simple-framebuffer at HDMI/composite geometry. The SPI panel then displays whatever the kernel hands it at its own 240×240 viewport, but the console contents were rendered for a much wider fb, so the right ~20 % of the screen is cropped. Reboots show the symptom in the original report.

64-bit Pi OS and Pi 4 / Pi Zero 2 W don't see it because module ordering / device probe is faster and the SPI panel lands first.

## Fix

The reporter (`@grandinquisitor`) confirmed two changes resolve it, and the panel now initializes at ~18 s instead of 35+ s:

1. Force-load the SPI + DRM MIPI panel modules early via `modules-load.d` so `systemd-modules-load.service` brings them up in early userspace.
2. Set `enable_tvout=0` in `config.txt` so the firmware doesn't reserve a composite-TV framebuffer that can interleave with the SPI panel's fb allocation on Pi Zero / Pi 1 / CM1.

This PR wires both into the installer, gated on `use_mipi_driver()` so legacy `fb_st7789v` installs are unaffected:

- New template `templates/pitft.conf` listing `spi_bcm2835`, `drm_mipi_dbi`, `panel_mipi_dbi`.
- New `install_early_modules()` writes it to `/etc/modules-load.d/pitft.conf` whenever the MIPI driver is used.
- `uninstall_etc_modules()` now also `rm -f`s that file so it gets re-evaluated cleanly on every install / uninstall.
- `update_configtxt()` appends `enable_tvout=0` to the helper-managed overlay block on the MIPI path.

## Scope

- Applies to all four MIPI-path displays in `displays[]` (`st7789_240x240`, `st7789_240x320`, `st7789_240x135`, `st7789v_bonnet_240x240`). Same late-load mechanism affects them all on 32-bit Pi OS.
- Does **not** touch the legacy `fb_st7789v` kernel-module path — different code path, different bug, unrelated.

## Testing

Verified the diff applies cleanly and `python3 -c 'import ast; ast.parse(open("adafruit-pitft.py").read())'` is happy. End-to-end hardware testing best done on the exact reporter rig: **Pi Zero W, 32-bit Pi OS Bookworm Lite, 1.3" 240x240 ST7789 bonnet**, command:

```bash
sudo -E env PATH=$PATH python3 adafruit-pitft.py \
  --display=st7789v_bonnet_240x240 --rotation=0 --install-type=console
```

After reboot, the boot console output should be visible and not cropped on the right.

Closes #341
