### PR TITLE
Fix watchdog module name in read-only-fs.sh

### DIFF
--- a/read-only-fs.sh
+++ b/read-only-fs.sh
@@ -72,8 +72,12 @@ selectN() {
 	done
 }
 
-SYS_TYPES=(Pi\ 3\ /\ Pi\ Zero\ W All\ other\ models)
-WATCHDOG_MODULES=(bcm2835_wdog bcm2708_wdog)
+# Modern Raspberry Pi kernels expose a single watchdog driver, bcm2835_wdt,
+# for every BCM283x / BCM2711 / BCM2712 SoC (Pi 1 through Pi 5, including
+# all Zero variants). The legacy bcm2835_wdog and bcm2708_wdog names are
+# gone, so the per-model selector that used to pick between them is no
+# longer needed.
+WATCHDOG_MODULE=bcm2835_wdt
 OPTION_NAMES=(NO YES)
 
 echo -n "Enable boot-time read/write jumper? [y/N] "
@@ -98,10 +102,6 @@ echo -n "Enable kernel panic watchdog? [y/N] "
 read
 if [[ "$REPLY" =~ (yes|y|Y)$ ]]; then
 	INSTALL_WATCHDOG=1
-	echo "Target system type:"
-	selectN "${SYS_TYPES[0]}" \
-		"${SYS_TYPES[1]}"
-	WD_TARGET=$?
 fi
 
 # VERIFY SELECTIONS BEFORE CONTINUING --------------------------------------
@@ -118,7 +118,7 @@ else
 	echo "Install GPIO-halt: NO"
 fi
 if [ $INSTALL_WATCHDOG -eq 1 ]; then
-	echo "Enable watchdog: YES (${SYS_TYPES[WD_TARGET-1]})"
+	echo "Enable watchdog: YES"
 else
 	echo "Enable watchdog: NO"
 fi
@@ -221,10 +221,8 @@ fi
 # Install watchdog if requested
 if [ $INSTALL_WATCHDOG -ne 0 ]; then
 	apt-get install -y --force-yes watchdog
-	# $MODULE is specific watchdog module name
-	MODULE=${WATCHDOG_MODULES[($WD_TARGET-1)]}
 	# Add to /etc/modules, update watchdog config file
-	append1 /etc/modules $MODULE $MODULE
+	append1 /etc/modules $WATCHDOG_MODULE $WATCHDOG_MODULE
 	replace /etc/watchdog.conf "#watchdog-device" "watchdog-device"
 	replace /etc/watchdog.conf "#max-load-1" "max-load-1"
 	# Start watchdog at system start and start right away


### PR DESCRIPTION
Fixes #6.

## The bug

`read-only-fs.sh` declared:

```bash
WATCHDOG_MODULES=(bcm2835_wdog bcm2708_wdog)
```

Neither of these module names exists on current Raspberry Pi OS kernels. The Linux watchdog driver for every Pi SoC (BCM2835 / BCM2836 / BCM2837 / BCM2711 / BCM2712, so Pi 1 through Pi 5 including all Zero variants) is `bcm2835_wdt`. The legacy `*_wdog` naming was retired upstream years ago, and `bcm2708_wdog` was never the right name for this driver in the first place.

Result: anyone who answered **YES** to "Enable kernel panic watchdog?" during `read-only-fs.sh` setup would hit a boot-time failure:

```
systemd-modules-load[xxx]: Failed to find module 'bcm2835_wdog'
systemd-modules-load.service: Failed with result 'exit-code'.
```

…and the watchdog itself wouldn't be loaded. The issue's reporter ([@JacoFourie](https://github.com/JacoFourie) and [@PaintYourDragon](https://github.com/PaintYourDragon)) identified the rename back in 2019 and asked for a PR; this is that PR.

## The fix

Since the same module name now serves every Pi SoC, the per-model selector ("Pi 3 / Pi Zero W" vs. "All other models") doesn't have a meaningful answer anymore — both branches would have to load `bcm2835_wdt`. So this PR:

- replaces `WATCHDOG_MODULES=(bcm2835_wdog bcm2708_wdog)` with a single `WATCHDOG_MODULE=bcm2835_wdt` constant
- drops the now-pointless `selectN` prompt and `WD_TARGET` index logic
- simplifies the "Enable watchdog: YES (...)" summary line to just "Enable watchdog: YES"

(The `selectN` helper function itself is left in place — it's harmless and a maintainer might want it for a future prompt.)

## Verification

Confirmed on Pi 5, kernel 6.12.75 (current Pi OS):

```
$ modinfo bcm2835_wdt | head -5
name:           bcm2835_wdt
filename:       (builtin)
license:        GPL
file:           drivers/watchdog/bcm2835_wdt
description:    Driver for Broadcom BCM2835 watchdog timer

$ cat /sys/class/watchdog/watchdog0/identity
Broadcom BCM2835 Watchdog timer
```

`bash -n read-only-fs.sh` clean.

(Note: on current kernels `bcm2835_wdt` is built into the kernel rather than a loadable module, so `/etc/modules-load.d/` entries for it are silently a no-op — the watchdog comes up automatically via device-tree. But the entry is harmless and remains correct for any future kernel that splits the driver back out, plus it produces no error.)
