### PR TITLE
Fix right-side blackout on PiTFT console (#341)

### DIFF
--- a/adafruit-pitft.py
+++ b/adafruit-pitft.py
@@ -584,7 +584,12 @@ def install_console():
     # adding new version
     shell.pattern_replace("/etc/rc.local", '^exit 0', "# disable console blanking on PiTFT\\nsudo sh -c \"TERM=linux setterm -blank 0 >/dev/tty0\"\\nexit 0")
 
-    # Set the console font to Terminus 6x12
+    # Set the console font to Terminus 6x12. 6px-wide glyphs give 40
+    # cols across a 240px PiTFT - more readable text density than 8x16's
+    # 30 cols. The grid-vs-font mismatch that used to leave the right
+    # ~25% of the panel unpainted at the shell prompt (issue #341) is
+    # handled by con2fbmap-helper.sh re-running setupcon after fbcon
+    # attaches to the SPI framebuffer.
     shell.reconfig("/etc/default/console-setup", "^.*FONTFACE.*$", "FONTFACE=\"Terminus\"")
     shell.reconfig("/etc/default/console-setup", "^.*FONTSIZE.*$", "FONTSIZE=\"6x12\"")
 

--- a/templates/con2fbmap-helper.sh
+++ b/templates/con2fbmap-helper.sh
@@ -44,11 +44,16 @@ is_spi_tft_fb() {
     fi
 
     # 2) Device-path match. For panel-mipi-dbi-spi the fbdev name is
-    #    "mipi_dbi" which does not contain the configured display_type,
-    #    but the device path under sysfs lives below the SPI controller
-    #    (e.g. .../soc/.../spi@.../spi0.0/...). Match any SPI slave on
+    #    "panel-mipi-dbid" / "mipi_dbi" which does not contain the
+    #    configured display_type, but the device path under sysfs lives
+    #    below the SPI controller (e.g. .../soc/.../spi@.../spi0.0
+    #    or .../soc/.../spi@.../spi0.0/...). Match any SPI slave on
     #    spi0.0, which is where the installer wires SPI TFT panels.
-    if [ -n "${devpath}" ] && [[ "${devpath}" == *"/spi0.0/"* ]]; then
+    #    Accept both the bare leaf path (.../spi0.0) and any child path
+    #    (.../spi0.0/...); earlier versions required a trailing slash
+    #    and missed the leaf case used by panel-mipi-dbi-spi.
+    if [ -n "${devpath}" ] && \
+       { [[ "${devpath}" == *"/spi0.0" ]] || [[ "${devpath}" == *"/spi0.0/"* ]]; }; then
         # Belt-and-braces: exclude framebuffers that are obviously not
         # the SPI TFT (e.g. vc4drmfb, simple-framebuffer). Those should
         # not have spi0.0 in their devpath, but guard anyway.
@@ -102,6 +107,26 @@ echo "Console mapped to framebuffer ${found_fb}"
 # resets the terminal which prompts fbcon to repaint the active console.
 if [ -w /dev/tty1 ]; then
     printf '\033c' > /dev/tty1 2>/dev/null || true
+fi
+
+# Re-apply the configured console font, now that fbcon is attached to
+# the SPI TFT framebuffer. Background (issue #341): when fbcon first
+# attaches to the SPI panel it sizes its character grid against the
+# kernel built-in 8x8 boot font (e.g. 30 columns on a 240px panel). The
+# normal console-setup.service runs setfont *before* the SPI panel
+# probes here (it targets the dummy/vc4 console), so when the SPI panel
+# eventually takes over the console its grid never gets resized for the
+# narrower 6px-wide Terminus 6x12 font - the kernel keeps painting a
+# 30-cell grid using 6px glyphs in 8px slots, leaving the right ~25%
+# of the panel unpainted at the shell prompt.
+#
+# Re-running setupcon here, *after* con2fbmap, lands a second setfont
+# on the SPI fbcon while it is idle, which triggers the grid recompute
+# (30 cols * 8 px slot -> 40 cols * 6 px = full 240 px width).
+if command -v setupcon >/dev/null 2>&1; then
+    echo "Re-applying console font to refresh fbcon character grid..."
+    setupcon --force --save-only >/dev/null 2>&1 || true
+    setupcon --force </dev/tty1 >/dev/tty1 2>&1 || true
 fi
 
 exit 0


### PR DESCRIPTION
### Symptom

After the installer ran on a Pi Zero W + 1.3" Joystick Bonnet (240x240
ST7789V via the upstream `panel-mipi-dbi-spi` overlay) on 32-bit
Raspbian Bookworm Lite, boot was visible end-to-end (good — that's
what #379 fixed). **But the moment the shell prompt appeared, the
right ~25 % of the panel went black** and stayed black through scroll:

![Before — right side blacks out at prompt](https://raw.githubusercontent.com/makermelissa-piclaw/Raspberry-Pi-Installer-Scripts/screenshots-branch/341/before-prompt-right-side-black.jpg)

While debugging, a second pre-existing bug surfaced in
`con2fbmap-helper.sh` from #378: the helper was hitting its 60 s
timeout (the display still worked only because `fb0` happened to be
the SPI panel anyway, so the unmapped console got drawn to it by
accident). Both bugs are fixed here.

### Bug 1 — fbcon character grid stale across `console-setup`'s `setfont`

The kernel emits this at boot:

```
[ 19.778] Console: switching to colour frame buffer device 30x30
```

That's the SPI panel handing fbcon a 30 × 30 character grid:
`240 / 8 = 30` columns of the kernel's built-in 8 × 8 boot font.

`console-setup.service` runs `setfont` with the configured Terminus
6x12 font, but it runs **before** the SPI panel probes (it targets
the dummy/vc4 console). When the SPI panel takes over the console
afterwards it inherits that 30-column count rather than recomputing
for the now-active 6 px glyphs. So each cell renders a 6 px-wide
glyph in an 8 px slot:

```
painted width = 30 cols  * 6 px = 180 px out of 240 px
right strip   = 30 cells * 2 px =  60 px never written
```

`stty -F /dev/tty1 size` still reports `20 40` to userspace, so apps
draw to columns 31–40 expecting paint, and get nothing.

**Re-running `setfont` (via `setupcon`) *after* fbcon is attached to
the SPI fb and the console is idle does trigger the grid recompute**
— the visible width jumps to the full 240 px and 40 cols × 20 rows
become usable. `con2fbmap-helper.sh` already runs at exactly the
right moment (it waits for the SPI fb to appear, then maps the
console). This PR extends that helper to call `setupcon --force`
once it has done the mapping.

Using `setupcon` (not a hard-coded `setfont …Terminus6x12…`) means
the rerun honors whatever font the user has set in
`/etc/default/console-setup`, so this also works for anyone who
prefers a different size.

### Bug 2 — `con2fbmap-helper.sh` device-path match missed `panel-mipi-dbi-spi`

`/sys/class/graphics/fb0/name` for this driver is `panel-mipi-dbid`
(note the missing `-spi` suffix), so the configured-name match
(`*panel-mipi-dbi-spi*`) was always going to miss. The device-path
fallback was supposed to catch it, but matched only `*/spi0.0/*`
(requires a child path with trailing slash), while the resolved
devpath for the upstream MIPI driver is the bare leaf
`…/spi_master/spi0/spi0.0` with no child node. Accepting either form
makes the helper actually find the panel:

```
con2fbmap-helper.sh[284]: SPI TFT framebuffer ready on /dev/fb0, mapping console...
con2fbmap-helper.sh[284]: Console mapped to framebuffer 0
con2fbmap-helper.sh[284]: Re-applying console font to refresh fbcon character grid...
```

(Previously it timed out after 60 s.)

### Result

Same boot, now with `Terminus 6x12` kept and the full panel painted:

![After — full 240 px width, 6x12 font preserved](https://raw.githubusercontent.com/makermelissa-piclaw/Raspberry-Pi-Installer-Scripts/screenshots-branch/341/after-installer-6x12.jpg)

40 cols × 20 rows of readable text, no right-side gap, shell prompt
fills full width.

### Diagnostics that ruled out alternative causes

To make sure this wasn't an x-offset / GRAM-window issue (ST7789V
has 320 × 240 of GRAM, only 240 × 240 visible at rotation 0), I
wrote a 4-quadrant test pattern directly to `/dev/fb0`:

```
cols   0– 59 = RED
cols  60–119 = GREEN
cols 120–179 = BLUE
cols 180–239 = YELLOW
```

All four quadrants showed up on the panel at equal width with
yellow reaching the right edge, confirming the visible window is
GRAM cols 0-239 with no offset and the driver is mapping
correctly — the right-side blackout is strictly an fbcon
character-grid issue.

### Files touched

- `adafruit-pitft.py` — clarifying comment only; `FONTSIZE="6x12"`
  is unchanged.
- `templates/con2fbmap-helper.sh`
  - Fix devpath match so `/spi0.0` leaves (not just `/spi0.0/`
    children) are recognized.
  - After mapping the console to the SPI fb, call
    `setupcon --force` to land a second `setfont` on the now-bound
    fbcon. This recomputes the character grid against the
    configured font, restoring the right ~25% of the panel that
    used to go unpainted at the shell prompt.

### Stacks on / relates to

- Stacks on #379 (force-early-load MIPI modules so the SPI panel
  attaches before getty). That PR made boot visible; this one
  makes what's drawn after boot use the full panel width.
- Extends behavior of `con2fbmap-helper.sh` shipped in #378.
- No changes to the uninstall path (it already removes
  `con2fbmap.service` + helper).

Closes #341
