### PR TITLE
Add SPDX license headers to i2smic.py and i2s_mic_module/

### DIFF
--- a/i2s_mic_module/Makefile
+++ b/i2s_mic_module/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Carter Nelson for Adafruit Industries
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 MOD_NAME	:= snd-i2smic-rpi
 
 ifneq ($(KERNELRELEASE),)

--- a/i2s_mic_module/README.md
+++ b/i2s_mic_module/README.md
@@ -1,3 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2020 Carter Nelson for Adafruit Industries
+SPDX-FileCopyrightText: 2018 Huan Truong <htruong@tnhh.net>
+
+SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
 **Driver for the Adafruit I2S MEMS Microphone**
 
 [Product learn page on Adafruit](https://learn.adafruit.com/adafruit-i2s-mems-microphone-breakout/overview).

--- a/i2s_mic_module/dkms.conf
+++ b/i2s_mic_module/dkms.conf
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Carter Nelson for Adafruit Industries
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 PACKAGE_NAME="snd-i2smic-rpi"
 PACKAGE_VERSION="0.1.0"
 MAKE="KDIR=/lib/modules/$kernelver/build MDIR=/lib/modules/$kernelver make"

--- a/i2s_mic_module/snd-i2smic-rpi.c
+++ b/i2s_mic_module/snd-i2smic-rpi.c
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2020 Carter Nelson for Adafruit Industries
+// SPDX-FileCopyrightText: 2018 Huan Truong <htruong@tnhh.net>
+// SPDX-FileCopyrightText: Paul Creaser
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * =====================================================================================
  *

--- a/i2s_mic_module/snd-i2smic-rpi.h
+++ b/i2s_mic_module/snd-i2smic-rpi.h
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2020 Carter Nelson for Adafruit Industries
+// SPDX-FileCopyrightText: 2018 Huan Truong <htruong@tnhh.net>
+// SPDX-FileCopyrightText: Paul Creaser
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 #ifndef _SND_I2SMIC_RPI_H_
 #define _SND_I2SMIC_RPI_H_
 

--- a/i2smic.py
+++ b/i2smic.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 import os
 
 try:


### PR DESCRIPTION
Closes #243

Adds SPDX license headers to clarify licensing on the files called out in the issue:

- `i2smic.py` → **MIT** (Adafruit-authored installer script, per the convention used for our other installer scripts).
- `i2s_mic_module/snd-i2smic-rpi.c`
- `i2s_mic_module/snd-i2smic-rpi.h`
- `i2s_mic_module/Makefile`
- `i2s_mic_module/dkms.conf`
- `i2s_mic_module/README.md` → all **GPL-2.0-or-later**, matching the existing `MODULE_LICENSE("GPL v2")` declaration in `snd-i2smic-rpi.c` (the kernel maps the "GPL v2" string to GPL-2.0-or-later).

Headers follow the SPDX / REUSE convention already used by `st7789_module/` in this repo (`SPDX-License-Identifier:` on its own line, using `//` for C, `#` for Makefile/dkms.conf/Python, and an HTML comment for the README).

Copyright lines pulled from `git log` and the existing banner comment in `snd-i2smic-rpi.c` (Carter Nelson for Adafruit's Pi4 mods; Huan Truong and Paul Creaser as the original authors).

Follow-up issue #244 covers adding an automatic header check across the repo.