### PR TITLE
README: fix dead i2samp.sh curl URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Some scripts for helping install Adafruit HATs, bonnets, add-on's, & friends!
 
 Many scripts are based heavily on get.pimoroni.com scripts!
 
-  * Install i2s amplifier with: curl -sS https://raw.githubusercontent.com/adafruit/Raspberry-Pi-Installer-Scripts/main/i2samp.sh | bash
+  * Install i2s amplifier: see the [Adafruit MAX98357 I2S Amp guide](https://learn.adafruit.com/adafruit-max98357-i2s-class-d-mono-amp/raspberry-pi-usage), or follow the [Python script setup](#python-scripts) below and run `sudo python3 i2samp.py`.
 
 ## Python Scripts
 


### PR DESCRIPTION
Closes #301

The README's top bullet told users to install the I2S amplifier with:

```bash
curl -sS https://raw.githubusercontent.com/adafruit/Raspberry-Pi-Installer-Scripts/main/i2samp.sh | bash
```

That URL has been returning **404** since `i2samp.sh` was moved into `converted_shell_scripts/` in April 2024 (commit 06deceb). Users piping that into bash were running `404: Not Found` as a shell script, which is what the original reporter hit on 32-bit Bookworm.

The Adafruit Learn guide already directs users to fetch and run `i2samp.py`, and `i2samp.py` uses the built-in `googlevoicehat-soundcard` dtoverlay \u2014 no kernel module is compiled, so the 32-bit/64-bit kernel/userspace mismatch from the original report doesn't apply to the current script.

This PR just updates the README bullet to point at the Learn guide and the existing **Python Scripts** section in the same README.

Melissa is updating the remaining Learn guides that still reference `i2samp.sh` separately.