### PR TITLE
Gate raspi-config calls behind Shell.run_raspi_config() (fixes #321)

### DIFF
--- a/adafruit-pitft.py
+++ b/adafruit-pitft.py
@@ -595,7 +595,7 @@ def install_console():
 
     print("Setting raspi-config to boot to console w/o login...")
     shell.chdir(target_homedir)
-    shell.run_command("raspi-config nonint do_boot_behaviour B2")
+    shell.run_raspi_config("do_boot_behaviour B2")
 
     # remove fbcp
     shell.pattern_replace("/etc/rc.local", "^.*fbcp.*$")
@@ -608,10 +608,10 @@ def uninstall_console():
     if is_desktop:
         print("Restoring Desktop Environment...")
         shell.run_command("apt-get -y install rpd-plym-splash")     # Install Splash Screen
-        shell.run_command("raspi-config nonint do_boot_splash 0")   # Enable Splash Screen
+        shell.run_raspi_config("do_boot_splash 0")                  # Enable Splash Screen
         if not shell.is_minimum_version("trixie"):
             shell.run_command("apt-get -y install raspberrypi-ui-mods") # Reinstall Raspberry Pi OS UI mods
-        shell.run_command("raspi-config nonint do_boot_target B2")  # Boot to Desktop
+        shell.run_raspi_config("do_boot_target B2")                 # Boot to Desktop
 
     if shell.exists("/etc/systemd/system/con2fbmap.service"):
         print("Removing console fbcon map service...")
@@ -678,10 +678,10 @@ def install_mirror():
     # if desktop environment is installed...
     if is_desktop:
         print("Setting raspi-config to boot to desktop w/o login...")
-        shell.run_command("raspi-config nonint do_boot_behaviour B4")
+        shell.run_raspi_config("do_boot_behaviour B4")
 
     # Disable overscan compensation (use full screen):
-    shell.run_command("raspi-config nonint do_overscan 1")
+    shell.run_raspi_config("do_overscan 1")
     # Set up HDMI parameters:
     print("Configuring boot/config.txt for forced HDMI")
     shell.reconfig(f"{boot_dir}/config.txt", "^.*hdmi_force_hotplug.*$", "hdmi_force_hotplug=1")
@@ -789,7 +789,7 @@ def uninstall_fbcp():
     if shell.exists("/etc/systemd/system/fbcp.service"):
         shell.run_command("sudo systemctl disable fbcp.service")
     # Set up HDMI parameters:
-    shell.run_command("raspi-config nonint do_overscan 0")
+    shell.run_raspi_config("do_overscan 0")
     print("Configuring boot/config.txt for default HDMI")
     shell.reconfig(f"{boot_dir}/config.txt", "^.*hdmi_force_hotplug.*$", "hdmi_force_hotplug=0")
     shell.pattern_replace(f"{boot_dir}/config.txt", "^.*#.*dtoverlay=vc4-kms-v3d.*$", "dtoverlay=vc4-kms-v3d")

--- a/adafruit_fanservice.py
+++ b/adafruit_fanservice.py
@@ -56,7 +56,7 @@ Run time < 1 minute. Reboot not required.""")
 
     if shell.is_raspberry_pi():
         shell.info('Enabling Raspberry Pi Fan Service on GPIO 4')
-        shell.run_command("sudo raspi-config nonint do_fan 0 4")
+        shell.run_raspi_config("do_fan 0 4")
         shell.info('Done!')
         shell.prompt_reboot()
     else:

--- a/joy-bonnet.py
+++ b/joy-bonnet.py
@@ -83,11 +83,11 @@ Updating package index files...""")
     print("Configuring system...")
 
     # Enable I2C using raspi-config
-    shell.run_command("sudo raspi-config nonint do_i2c 0")
+    shell.run_raspi_config("do_i2c 0")
 
     # Disable overscan compensation (use full screen):
     if disable_overscan:
-        shell.run_command("sudo raspi-config nonint do_overscan 1")
+        shell.run_raspi_config("do_overscan 1")
 
     if install_halt:
         if shell.pattern_search("/etc/rc.local", "gpio-halt"):

--- a/pitft-fbcp.py
+++ b/pitft-fbcp.py
@@ -186,7 +186,7 @@ TFT MADCTL rotate: {selected_tftrotate['label']}
     print("Configuring PiTFT...")
 
     # Enable SPI using raspi-config
-    shell.run_command("raspi-config nonint do_spi 0")
+    shell.run_raspi_config("do_spi 0")
 
     # Set up HDMI rotation
     shell.reconfig(f"{boot_config}", "^.*display_rotate.*$", f"display_rotate={selected_fbrotate['value']}")

--- a/raspi-blinka.py
+++ b/raspi-blinka.py
@@ -62,18 +62,18 @@ def set_raspiconfig():
     Enable various Raspberry Pi interfaces
     """
     print("Enabling I2C")
-    shell.run_command("sudo raspi-config nonint do_i2c 0")
+    shell.run_raspi_config("do_i2c 0")
     print("Enabling SPI")
-    shell.run_command("sudo raspi-config nonint do_spi 0")
+    shell.run_raspi_config("do_spi 0")
     print("Enabling Serial")
-    if not shell.run_command("sudo raspi-config nonint do_serial_hw 0", suppress_message=True):
-        shell.run_command("sudo raspi-config nonint do_serial 0")
+    if not shell.run_raspi_config("do_serial_hw 0", suppress_message=True):
+        shell.run_raspi_config("do_serial 0")
     print("Enabling SSH")
-    shell.run_command("sudo raspi-config nonint do_ssh 0")
+    shell.run_raspi_config("do_ssh 0")
     print("Enabling Camera")
-    shell.run_command("sudo raspi-config nonint do_camera 0")
+    shell.run_raspi_config("do_camera 0")
     print("Disable raspi-config at Boot")
-    shell.run_command("sudo raspi-config nonint disable_raspi_config_at_boot 0")
+    shell.run_raspi_config("disable_raspi_config_at_boot 0")
 
 def update_python():
     print("Making sure Python 3 is the default")

--- a/raspi-spi-reassign.py
+++ b/raspi-spi-reassign.py
@@ -51,14 +51,14 @@ def valid_options(ce0_option, ce1_option):
 
 def disable_spi():
     print("Disabling SPI")
-    shell.run_command("sudo raspi-config nonint do_spi 1")
+    shell.run_raspi_config("do_spi 1")
 
 def enable_spi():
     print("Enabling SPI")
-    shell.run_command("sudo raspi-config nonint do_spi 0")
+    shell.run_raspi_config("do_spi 0")
 
 def spi_disabled():
-    return shell.run_command("sudo raspi-config nonint get_spi", suppress_message=True, return_output=True).strip() == "1"
+    return shell.run_raspi_config("get_spi", suppress_message=True, return_output=True).strip() == "1"
 
 def remove_custom():
     shell.pattern_replace(f"{boot_dir}/config.txt", 'dtoverlay=spi0-[0-2]cs,cs.*?\n', multi_line=True)

--- a/retrogame.py
+++ b/retrogame.py
@@ -77,7 +77,7 @@ Run time <1 minute. Reboot recommended.
         if CONFIG_NAME == "bonnet":
             # If Bonnet, make sure I2C is enabled.  Call the I2C
             # setup function in raspi-config (noninteractive):
-            shell.run_command("raspi-config nonint do_i2c 0")
+            shell.run_raspi_config("do_i2c 0")
 
         # Start on boot
         if shell.run_command("grep retrogame /etc/rc.local", suppress_message=True):

--- a/rtc.py
+++ b/rtc.py
@@ -127,7 +127,7 @@ def main():
         if i2creq == "yes":
             print()
             if shell.prompt("Hardware requires I2C, enable now?", force_arg="y", default="n"):
-                shell.run_command("sudo raspi-config nonint do_i2c 0")
+                shell.run_raspi_config("do_i2c 0")
 
         if not dt_check():
             shell.bail(


### PR DESCRIPTION
## Summary

The Python installer scripts in this repo shell out to `raspi-config nonint ...` to toggle SPI/I2C, set overscan, change boot behaviour, configure the fan service, etc. `raspi-config` is only shipped (and only honored) on Raspberry Pi OS — on DietPi, Ubuntu, and other Debian-based distros the binary is absent and `shell.run_command` returns falsy on the missing executable, so the tweak silently doesn't happen and the user sees a confusing `command not found` line mid-install. That's the underlying "non-Pi-OS distro" gap behind #321; the reporter's specific `is_wayland()`/`loginctl` complaint was already fixed when that helper was deleted in d14339d, but the broader raspi-config-unavailable problem on the same distro remained.

## Approach

[adafruit/Adafruit_Python_Shell#38](https://github.com/adafruit/Adafruit_Python_Shell/pull/38) (now merged + released) added a reusable `Shell.run_raspi_config(args, suppress_message=False, return_output=False, run_as_user=None)` that gates on `is_raspberry_pi_os()` and short-circuits to a no-op on non-Pi-OS hosts (returning `True`, or `""` when `return_output=True` so `.strip()` callers stay happy).

This PR migrates every `raspi-config nonint` call site in the repo's Python installers to use it.

| File | Sites | What they toggle |
| --- | --- | --- |
| `adafruit-pitft.py` | 6 | `do_boot_behaviour`, `do_boot_splash`, `do_boot_target`, `do_overscan` ×2 |
| `raspi-blinka.py` | 7 | `do_i2c`, `do_spi`, `do_serial_hw`, `do_serial`, `do_ssh`, `do_camera`, `disable_raspi_config_at_boot` |
| `raspi-spi-reassign.py` | 3 | `do_spi` ×2 + `get_spi` (uses `return_output=True` + `.strip()`) |
| `joy-bonnet.py` | 2 | `do_i2c`, `do_overscan` |
| `retrogame.py` | 1 | `do_i2c` |
| `pitft-fbcp.py` | 1 | `do_spi` |
| `rtc.py` | 1 | `do_i2c` |
| `adafruit_fanservice.py` | 1 | `do_fan` — was previously gated only on `is_raspberry_pi()`, which is true on DietPi-on-Pi-hardware |

Total: **22 call sites across 8 files**, +22 / −22 net.

The leading `sudo` on the old `run_command` lines is dropped: all of these installers already require root (`require_root()` or equivalent), so the inner sudo was redundant.

## Out of scope

Bash-only scripts in this repo (`pi-eyes.sh`, `arcade-bonnet.sh`, `rgb-matrix.sh`, `retrogame.sh`, `spectro.sh`) still call `raspi-config` directly. They don't use `adafruit_shell` and would need a different fix; happy to follow up separately if you want that too.

## Test plan

- Syntax (`ast.parse`) clean across all 8 files (pre-existing `SyntaxWarning`s on invalid escape sequences are unrelated).
- Confirmed via `ast` walk that all **22** migrated call sites resolve to syntactically valid `shell.run_raspi_config(...)` invocations, with `suppress_message` / `return_output` kwargs preserved on the three sites that use them.
- On this Pi (Raspberry Pi OS), with `Shell.run_command` monkey-patched to record calls: `run_raspi_config("do_overscan 1")` forwards to `run_command("raspi-config nonint do_overscan 1", ...)` exactly as before.
- On simulated non-Pi-OS (`is_raspberry_pi_os` patched to `False`): all calls short-circuit, return truthy / empty string, zero `run_command` invocations.

## References

- Closes #321.
- Depends on adafruit/Adafruit_Python_Shell#38 (merged + released).