### PR TITLE
adafruit-pitft: fix overlay_params lookup (fixes #340)

### DIFF
--- a/adafruit-pitft.py
+++ b/adafruit-pitft.py
@@ -510,8 +510,14 @@ def update_configtxt(rotation_override=None, tinydrm_install=False):
 
     if tinydrm_install: # Use overlay params for Wayland
         overlay += ",drm"
-        if "overlay_params" in pitft_config and pitftrot in pitft_config["overlay_params"] and pitft_config["overlay_params"][pitftrot] is not None:
-            overlay += "," + pitft_config["overlay_params"][pitftrot]
+        # overlay_params lives under the touchscreen sub-dict (the lookup
+        # used to read it from the top level of pitft_config, which never
+        # had the key — see issue #340).
+        touch_cfg = pitft_config.get("touchscreen", {})
+        params_by_rot = touch_cfg.get("overlay_params", {})
+        rot_params = params_by_rot.get(pitftrot)
+        if rot_params:
+            overlay += "," + rot_params
     config_text_base = shell.load_template("templates/config_text_base.txt", date=shell.date(), overlay=overlay)
     if config_text_base is None:
         shell.bail("Unable to load config_text_base template!")


### PR DESCRIPTION
## Summary

Fixes #340 — touch coordinates inverted at `rotation=90` (and effectively unconfigured at every rotation) for PiTFT mirror installs.

## Root cause

`update_configtxt()` reads `overlay_params` from the top level of `pitft_config`, but the data is nested under `pitft_config["touchscreen"]["overlay_params"]`. The `if` is always `False`, so the `touch-invx` / `touch-invy` / `touch-swapxy` parameters never get appended to the `dtoverlay` line — for **any** PiTFT display, at **any** rotation, in mirror install mode.

This was introduced in commit 34817dc ("Fix capacitive touch rotations", 2024) — the same commit that added the per-rotation `overlay_params` data structure. The values were placed under `touchscreen`, but the lookup was written against the top level. Symptoms were subtle enough (touch only inverted at specific rotations, which calibration tools partially mask) that the bug went unnoticed.

## Fix

One-liner: read `overlay_params` from `pitft_config["touchscreen"]["overlay_params"]` where it actually lives. The patch also tidies the lookup into three clear steps and adds a comment pointing at this issue for future readers.

## Verification

Tested on real hardware: Raspberry Pi 4 + Adafruit 2.8" PiTFT capacitive (28c), Raspberry Pi OS Trixie Desktop 64-bit, kernel 6.12.

**Before the fix:**
```
$ grep pitft28 /boot/firmware/config.txt
dtoverlay=pitft28-capacitive,rotate=90,speed=64000000,fps=30,drm
```
No `touch-*` params — matches the reporter's symptoms exactly.

**After the fix:**
```
$ grep pitft28 /boot/firmware/config.txt
dtoverlay=pitft28-capacitive,rotate=90,speed=64000000,fps=30,drm,touch-swapxy,touch-invy
```

Then captured `evtest` events while tapping the four corners of the display in its rotated (landscape) orientation:

| Corner | ABS_X (0–319) | ABS_Y (0–239) |
|---|---|---|
| Top-left | 49 | 71 |
| Top-right | 293 | 78 |
| Bottom-left | 65 | 214 |
| Bottom-right | 258 | 207 |

Axes track the physical display correctly: TL→TR raises X, TL→BL raises Y. ✅

## Scope notes

- The fix applies to all PiTFT models that use `overlay_params` (28r, 28c, 35r). Only 28c was verifiable on my bench, but the lookup is uniform across displays so 28r/35r should be unblocked by the same change.
- The PR fixes only the lookup typo. Whether the **values** in the `overlay_params` table are correct for every rotation × display combination is a separate question; the table value for rotation=90 on 28c is verified above. If other rotations/displays surface follow-up issues, they can be addressed independently now that the params are actually being applied.

Closes #340.