### PR TITLE
rgb-matrix: add CPU core isolation option for multi-core Pis

### DIFF
--- a/rgb-matrix.sh
+++ b/rgb-matrix.sh
@@ -26,6 +26,16 @@ if [ $HAS_PYTHON2 ] && ! [ $HAS_PYTHON3 ]; then
 	exit 0
 fi
 
+NUM_CORES=$(nproc --all)
+# Reserve the highest-numbered core (isolcpus is 0-indexed)
+ISOLCPU_CMD="isolcpus=$((NUM_CORES - 1))"
+
+# Boot config locations. Bookworm and later use /boot/firmware/;
+# pre-Bookworm releases use /boot/.
+CMDLINE_FILE=/boot/firmware/cmdline.txt
+if [ ! -f "$CMDLINE_FILE" ]; then
+	CMDLINE_FILE=/boot/cmdline.txt
+fi
 
 clear
 
@@ -52,6 +62,7 @@ fi
 INTERFACE_TYPE=0
 INSTALL_RTC=0
 QUALITY_MOD=0
+ISOL_CPU=0
 #SLOWDOWN_GPIO=5
 #MATRIX_SIZE=3
 
@@ -92,6 +103,11 @@ INTERFACES=( \
 QUALITY_OPTS=( \
   "Quality (disables sound, requires soldering on single matrix Bonnet/HAT)" \
   "Convenience (sound on, no soldering)" \
+)
+
+ISOLCPUS_OPTS=( \
+  "Do not reserve a core for driving the display" \
+  "Reserve a core for driving the display (recommended)" \
 )
 
 #SLOWDOWN_OPTS=( \
@@ -173,6 +189,17 @@ echo "What is thy bidding?"
 selectN "${QUALITY_OPTS[@]}"
 QUALITY_MOD=$?
 
+if [ "$NUM_CORES" -ge 2 ]; then
+	echo
+	echo "Your Pi has ${NUM_CORES} CPU cores. You can dedicate one"
+	echo "to driving the display. This reduces flicker when the"
+	echo "system is busy with other work, at the cost of one core"
+	echo "being unavailable for general use. This is the upstream"
+	echo "recommendation from hzeller/rpi-rgb-led-matrix."
+	selectN "${ISOLCPUS_OPTS[@]}"
+	ISOL_CPU=$?
+fi
+
 # VERIFY SELECTIONS BEFORE CONTINUING --------------------------------------
 
 echo
@@ -186,6 +213,9 @@ echo "Optimize: ${QUALITY_OPTS[$QUALITY_MOD]}"
 if [ $QUALITY_MOD -eq 0 ]; then
 	echo "Reminder: you must SOLDER a wire between GPIO4"
 	echo "and GPIO18, and internal sound is DISABLED!"
+fi
+if [ "$NUM_CORES" -ge 2 ]; then
+	echo "Isolate CPU for display driving: ${ISOLCPUS_OPTS[$ISOL_CPU]}"
 fi
 echo
 echo -n "CONTINUE? [y/n] "
@@ -258,6 +288,18 @@ if [ $QUALITY_MOD -eq 0 ]; then
 else
 	# Remove from blacklist
 	rm -f /etc/modprobe.d/blacklist-rgb-matrix.conf
+fi
+
+# Strip any previously-added isolcpus=N token first so the add path is
+# idempotent (e.g. re-running the installer, or moving the SD card from a
+# 4-core Pi to a 2-core Pi where the desired N differs). cmdline.txt is a
+# single line; collapse any doubled spaces left behind and trim trailing
+# whitespace.
+sed -i -E -e 's/(^| )isolcpus=[0-9]+( |$)/\1\2/g' -e 's/  +/ /g' -e 's/ $//' "$CMDLINE_FILE"
+if [ $ISOL_CPU -eq 1 ]; then
+	# Reserve a core for the matrix driver (upstream recommendation).
+	# Append the isolcpus=N token with a leading space.
+	sed -i "s/\$/ ${ISOLCPU_CMD}/" "$CMDLINE_FILE"
 fi
 
 # PROMPT FOR REBOOT --------------------------------------------------------


### PR DESCRIPTION
Adds an optional prompt to reserve a CPU core for driving the LED matrix display by appending `isolcpus=N` to `cmdline.txt`. This is the upstream recommendation from [hzeller/rpi-rgb-led-matrix](https://github.com/hzeller/rpi-rgb-led-matrix) for reducing flicker when the system is busy with other work.

### Behavior

- **Prompt only shown on multi-core Pis** (`$(nproc --all) >= 2`). Skipped on Pi 1 / Zero / Zero W where there is nothing to isolate.
- **N is computed dynamically** as `$(nproc --all) - 1` so it works on both 2-core and 4-core Pis. Pi Zero 2 W / 3 / 4 / 5 all get `isolcpus=3`.
- **Boot path detection:** `CMDLINE_FILE` defaults to `/boot/firmware/cmdline.txt` with a fallback to `/boot/cmdline.txt` for pre-Bookworm releases.
- **Fully idempotent and reversible.** Any existing `isolcpus=<digits>` token in `cmdline.txt` is stripped before the current N is appended, so re-running the installer — or migrating an SD card between Pis with different core counts — does not leave stale or duplicate tokens behind. Selecting *do not reserve* removes the token cleanly.

### Verification

Tested on a Raspberry Pi 4 (4 cores, Trixie) by exercising the `cmdline.txt` edits against a temporary copy:

- Clean add → `isolcpus=3` appended correctly.
- Double add → idempotent (token count stays at 1).
- Synthetic stale `isolcpus=7` token → cleaned up before correct N is appended.
- Round-trip add+remove → file restored byte-exactly to the original.
- Remove when no token present → no-op.

The full interactive prompt flow was also dry-run end-to-end (cancelling before the install step) to confirm the prompt appears in the right order and the summary line displays the chosen option.

### Relationship to #336

This supersedes #336 (originally proposed by @sciguy14) by salvaging its still-novel `isolcpus` feature on top of current `main`. The other improvements from that PR have already landed independently in `main` via subsequent commits:

- Bookworm `/boot/firmware/config.txt` path — done.
- Drop `--force-yes` from `apt-get` invocations — done (Python 2 support was removed entirely).
- `blacklist snd_bcm2835` for quality mode (also addresses #253) — done.
- Newer upstream RGB matrix commit — done (main is at `7a503494…`, newer than #336's bump).

#336 also had a small typo (`CONFIG_FILE=/boot/cmdline.txt` where `CMDLINE_FILE=` was intended) that this rewrite avoids.

cc @sciguy14 — thanks for the original idea.