### PR TITLE
rtc.py: fix bugs and modernize

### DIFF
--- a/rtc.py
+++ b/rtc.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 """
 Adafruit Raspberry Pi Real Time Clock Setup Script
 
@@ -17,9 +21,6 @@ was written for this script.
 Originally written by the - The Pimoroni Crew -
 
 Converted to Python by Melissa LeBlanc-Williams for Adafruit Industries
-
-
-Note: Currently Untested
 """
 
 try:
@@ -28,66 +29,48 @@ except ImportError:
     raise RuntimeError("The library 'adafruit_shell' was not found. To install, try typing: sudo pip3 install adafruit-python-shell")
 
 shell = Shell()
+shell.group = "RTC"
 
-productname = "Real Time Clock module" # the name of the product to install
-rtcsubtype = "ds1307"
-baseurl = "http://www.adafru.it"
-scriptname = "rtc.py" # the name of this script
+productname = "Real Time Clock module"  # the name of the product to install
 
-spacereq = 1 # minimum size required on root partition in MB
-debugmode = False # whether the script should use debug routines
-debuguser = None # optional test git user to use in debug mode
-debugpoint = None # optional git repo branch or tag to checkout
-forcesudo = True # whether the script requires to be ran with root privileges
-promptreboot = False # whether the script should always prompt user to reboot
-customcmd = True # whether to execute commands specified before exit
-i2creq = True # whether the i2c interface is required
-i2sreq = False # whether the i2s interface is required
-spireq = False # whether the spi interface is required
-uartreq = False # whether uart communication is required
-armhfonly = True # whether the script is allowed to run on other arch
-armv6 = True # whether armv6 processors are supported
-armv7 = True # whether armv7 processors are supported
-armv8 = True # whether armv8 processors are supported
-raspbianonly = True # whether the script is allowed to run on other OSes
-macosxsupport = False # whether Mac OS X is supported by the script
-osreleases = ( "Raspbian" ) # list os-releases supported
-oswarning = ( "Debian", "Ubuntu", "Mate" ) # list experimental os-releases
-squeezesupport = False # whether Squeeze is supported
-wheezysupport = False # whether Wheezy is supported
-jessiesupport = True # whether Jessie is supported
+i2creq = True  # whether the i2c interface is required
+raspbianonly = True  # whether the script is allowed to run on other OSes
+# os-releases supported (must be a tuple — single-element tuples require a
+# trailing comma, otherwise Python treats `("Raspbian")` as a bare string and
+# the `in` check below falls back to substring matching against the release
+# name)
+osreleases = ("Raspbian",)
+oswarning = ("Debian", "Ubuntu", "Mate")  # list experimental os-releases
+wheezysupport = False  # whether Wheezy is supported
 
-DEVICE_TREE = True
-ASK_TO_REBOOT = False
-CURRENT_SETTING = False
-UPDATED_DB = False
-
-BOOTCMD = "/boot/cmdline.txt"
 CONFIG = shell.get_boot_config()
-APTSRC = "/etc/apt/sources.list"
-INITABCONF = "/etc/inittab"
-BLACKLIST = "/etc/modprobe.d/raspi-blacklist.conf"
-LOADMOD = "/etc/modules"
-DTBODIR = "/boot/overlays"
+
 
 def raspbian_old():
     return shell.get_raspbian_version() in ("wheezy", "squeeze")
 
+
 def dt_check():
-    # Check if /boot/firmware/config.txt exists and de
+    # Device-tree is required. Bail only if config.txt explicitly disables
+    # it via a bare `device_tree=` line (legacy non-DT mode).
     return shell.exists(CONFIG) and not shell.pattern_search(CONFIG, "^device_tree=$")
 
-#Perform all global variables declarations as well as function definition
-#above this section for clarity, thanks!
+
+# Perform all global variables declarations as well as function definition
+# above this section for clarity, thanks!
+
 
 def main():
     os_release = shell.get_raspbian_version()
-    IS_SUPPORTED = os_release in osreleases
-    IS_EXPERIMENTAL = os_release in oswarning
+    is_supported = os_release in osreleases
+    is_experimental = os_release in oswarning
 
-    if not shell.is_armhf() or shell.is_arm64():
+    # All modern Raspberry Pi boards (Pi 2 and newer) are supported, including
+    # 64-bit Bookworm/Trixie on Pi 4/5. The original arch check only allowed
+    # 32-bit ARM, which incorrectly bailed out on every 64-bit Pi install.
+    if not (shell.is_armhf() or shell.is_arm64()):
         shell.bail("This hardware is not supported, sorry!\n"
-            "Config files have been left untouched")
+                   "Config files have been left untouched")
 
     if shell.is_raspberry_pi_os():
         if not wheezysupport and raspbian_old():
@@ -95,18 +78,15 @@ def main():
                 "\n--- Warning ---\n"
                 f"The {productname} installer\n"
                 "does not work on this version of Raspbian.\n"
-                r"Check https://github.com/{gitusername}/{gitreponame}"
-                "\nfor additional information and support")
+                "Check https://github.com/adafruit/Raspberry-Pi-Installer-Scripts\n"
+                "for additional information and support")
     elif raspbianonly:
-            shell.bail("This script is intended for Raspbian on a Raspberry Pi!")
+        shell.bail("This script is intended for Raspbian on a Raspberry Pi!")
     else:
-        if not IS_SUPPORTED and not IS_EXPERIMENTAL:
+        if not is_supported and not is_experimental:
             shell.bail(
                 "Your operating system is not supported, sorry!\n"
                 "Config files have been left untouched")
-
-    if forcesudo:
-        shell.require_root()
 
     print(f"\nThis script will install everything needed to use {productname}\n")
     shell.warn(
@@ -114,50 +94,60 @@ def main():
         "Always be careful when running scripts and commands\n"
         "copied from the internet. Ensure they are from a\n"
         "trusted source.\n"
-        "\n"
-        "If you want to see what this script does before\n"
-        "running it, you should run:\n"
-        "    \curl -sS $baseurl/$scriptname\n"
-        "\n"
     )
 
-    if shell.prompt("Do you wish to continue?", force_arg="y", default="n"):
-        print("\nChecking hardware requirements...")
-
-        if i2creq == "yes":
-            print()
-            if shell.prompt("Hardware requires I2C, enable now?", force_arg="y", default="n"):
-                shell.run_raspi_config("do_i2c 0")
-
-        if not dt_check():
-            shell.bail(
-                "Device Tree support required!\n"
-                "Config files have been left untouched\n"
-            )
-
-        rtc_values = ("ds1307", "ds3231", "pcf8523")
-        rtcsubtype = rtc_values[shell.select_n("What RTC would you like to install?", rtc_values) - 1]
-
-        print("Disabling any current RTC")
-        shell.run_command(f"sudo sed --in-place '/dtoverlay[[:space:]]*=[[:space:]]*i2c-rtc/d' {CONFIG}")
-
-        print(f"Adding DT overlay for {rtcsubtype}")
-        shell.write_text_file(CONFIG, f"dtoverlay=i2c-rtc,{rtcsubtype}", append=True)
-
-        print("Removing fake-hwclock")
-        shell.run_command("sudo apt-get -y remove fake-hwclock")
-        shell.run_command("sudo update-rc.d -f fake-hwclock remove")
-
-        if not shell.exists("/lib/udev/hwclock-set"):
-            shell.bail("Couldn't find /lib/udev/hwclock-set")
-
-        shell.warn("Configuring HW Clock")
-        shell.run_command("sudo sed --in-place '/if \[ -e \/run\/systemd\/system \] ; then/,+2 s/^#*/#/' /lib/udev/hwclock-set")
-        shell.prompt_reboot()
-
-    else:
+    if not shell.prompt("Do you wish to continue?", force_arg="y", default="n"):
         shell.warn("\nAborting...")
+        return
+
+    print("\nChecking hardware requirements...")
+
+    if i2creq:
+        print()
+        if shell.prompt("Hardware requires I2C, enable now?", force_arg="y", default="n"):
+            shell.run_raspi_config("do_i2c 0")
+
+    if not dt_check():
+        shell.bail(
+            "Device Tree support required!\n"
+            "Config files have been left untouched\n"
+        )
+
+    rtc_choices = ("ds1307", "ds3231", "pcf8523")
+    rtcsubtype = rtc_choices[shell.select_n(
+        "What RTC would you like to install?", rtc_choices
+    ) - 1]
+
+    print("Disabling any current RTC")
+    # Blank any existing `dtoverlay=i2c-rtc[,...]` line in config.txt. This
+    # uses Python regex semantics (\s for whitespace) rather than the POSIX
+    # `[[:space:]]` class used by the shell script's `sed` invocation.
+    shell.pattern_replace(CONFIG, r"^dtoverlay\s*=\s*i2c-rtc.*$")
+
+    print(f"Adding DT overlay for {rtcsubtype}")
+    shell.write_text_file(CONFIG, f"dtoverlay=i2c-rtc,{rtcsubtype}", append=True)
+
+    print("Removing fake-hwclock")
+    shell.run_command("sudo apt-get -y remove fake-hwclock")
+    shell.run_command("sudo update-rc.d -f fake-hwclock remove")
+
+    if not shell.exists("/lib/udev/hwclock-set"):
+        shell.bail("Couldn't find /lib/udev/hwclock-set")
+
+    shell.warn("Configuring HW Clock")
+    # Comment out the three-line block guarded by the systemd-running check
+    # in /lib/udev/hwclock-set so the kernel hwclock sync runs on systemd
+    # systems too (otherwise the RTC time isn't picked up at boot). Sed
+    # range address (`/pat/,+2`) has no clean pattern_replace equivalent,
+    # so shell out to the real sed.
+    shell.run_command(
+        r"sudo sed --in-place '/if \[ -e \/run\/systemd\/system \] ; then/,+2 s/^#*/#/' /lib/udev/hwclock-set"
+    )
+
+    shell.prompt_reboot()
+
 
 # Main function
 if __name__ == "__main__":
+    shell.require_root()
     main()


### PR DESCRIPTION
## What this changes

Fixes a pile of bugs in `rtc.py` that have been there since the original
shell-to-Python conversion. The file's docstring has carried the
`Note: Currently Untested` marker since 2020, and the bugs below are
mostly the kind of thing that would have shown up the first time anyone
actually ran it on hardware.

This PR matches the modernization pattern from joy-bonnet.py (#388) and
the SPDX-header cleanup from #382 / issue #243.

The shell version (`rtc.sh`) is left in place, per the conversion plan
to retire shell scripts to `converted_shell_scripts/` only after the
matching Learn guides are updated.

## Bugs fixed

1. **Arch check excluded every 64-bit Pi.** The original
   `not shell.is_armhf() or shell.is_arm64()` bail meant the script
   refused to run on **any** Raspberry Pi running 64-bit Bookworm or
   Trixie — i.e. the default install on Pi 4 and Pi 5. Replaced with
   `not (shell.is_armhf() or shell.is_arm64())`.

2. **`osreleases = ("Raspbian")` was a bare string, not a tuple.** The
   single-element tuple needs a trailing comma. As written, the `in`
   check on line 87 fell back to substring matching against the OS
   release name. Not a hot path (the script bailed before reaching it
   in most cases) but a real foot-gun.

3. **The "enable I2C?" prompt never fired.** The branch guard was
   `if i2creq == "yes":` but `i2creq` is a Python bool (`True`). Result:
   the RTC overlay was added to config.txt on systems that hadn't been
   configured for I2C yet. The shell script does prompt for this.

4. **SyntaxWarnings on Python 3.12+:**
   - Line 120: `"    \curl -sS $baseurl/$scriptname\n"` — `\c` isn't a
     valid escape sequence, raises `SyntaxWarning: invalid escape
     sequence '\c'` (slated to become a hard `SyntaxError`). Also the
     `$baseurl/$scriptname` was never substituted, so the user just saw
     literal bash-style variables. Removed the whole leftover-from-bash
     line since it never worked.
   - Line 155: the `sed` invocation used `\[` `\/` in a non-raw string,
     producing the same warning. Made the string raw.

5. **`shell.run_command("sudo sed '/.../d' …")` for blanking the
   pre-existing dtoverlay line** — replaced with `shell.pattern_replace`
   using Python regex (`\s`) rather than the POSIX `[[:space:]]` class
   that the shell version relied on. The matching style is what
   `adafruit-pitft.py` / `i2samp.py` / `pi-touch-cam.py` already use
   for config.txt edits. The hwclock-set sed range address (`/pat/,+2`)
   has no clean `pattern_replace` equivalent, so that one still shells
   out — same behavior as before.

6. **No trailing newline at EOF.** Minor, but fixed.

## Cleanup

- Added SPDX license header to match the i2smic.py treatment from #382.
- Moved `shell.require_root()` outside `main()` to match the
  joy-bonnet.py / retrogame.py pattern (per maintainer request). The
  dead `forcesudo` flag goes with it.
- Refactored the "Do you wish to continue?" branch to use an early
  abort return instead of nesting the entire happy path inside an
  `if` block. Smaller indent stack, easier to follow.
- Removed the large pile of dead pimoroni-template flags
  (`debugmode`, `debuguser`, `spacereq`, `armv6`/`7`/`8`, `i2sreq`,
  `spireq`, `uartreq`, `macosxsupport`, `squeezesupport`,
  `jessiesupport`, `armhfonly`, `BOOTCMD`, `APTSRC`, `INITABCONF`,
  `BLACKLIST`, `LOADMOD`, `DTBODIR`, `DEVICE_TREE`, `ASK_TO_REBOOT`,
  `CURRENT_SETTING`, `UPDATED_DB`) that the script never read.
- Dropped the stale `Note: Currently Untested` line from the docstring.

## How I verified

I don't have a physical RTC HAT on hand, but I ran the script end-to-end
on a Raspberry Pi 4 running Trixie (`aarch64`) with the destructive
calls mocked (`apt-get remove`, `update-rc.d`, `sed /lib/udev/...`, the
reboot prompt) and a synthetic `config.txt` pointed at by the
`get_boot_config` mock. The script:

- got past the arch check on `aarch64` — this is the headline bug fix,
  the previous version bailed immediately on this same Pi with `"This
  hardware is not supported, sorry!"`;
- prompted to enable I2C and called `raspi-config do_i2c 0` — the
  previous version silently skipped this entire branch;
- rendered the `select_n` picker, accepted `ds1307`;
- correctly blanked the pre-existing `dtoverlay = i2c-rtc,ds1307`
  line in the synthetic config.txt and appended the new
  `dtoverlay=i2c-rtc,ds1307` at the end;
- ran with the `-y` shortcut to auto-accept the continue prompt.

Running the **pre-PR version** against the same harness reproduces the
two `SyntaxWarning`s and the immediate arch-bail on this `aarch64`
host.

Hardware testing with a real RTC HAT would still be welcome before
this lands — happy to defer to anyone who has a DS1307 / DS3231 /
PCF8523 board lying around. The destructive paths (`apt-get remove
fake-hwclock`, hwclock-set sed) are unchanged from the previous Python
version.

## Out of scope

- `retrogame.py` has a separate set of bugs from its own conversion.
  Those will land in a follow-up PR rather than getting mixed in here.
- The shell version `rtc.sh` stays in place. Move to
  `converted_shell_scripts/` should follow once the Learn guide has
  been updated to reference the Python version.
