### PR TITLE
rtc.py: skip hwclock-set patch on Trixie+ instead of bailing

### DIFF
--- a/rtc.py
+++ b/rtc.py
@@ -131,18 +131,19 @@ def main():
     shell.run_command("sudo apt-get -y remove fake-hwclock")
     shell.run_command("sudo update-rc.d -f fake-hwclock remove")
 
-    if not shell.exists("/lib/udev/hwclock-set"):
-        shell.bail("Couldn't find /lib/udev/hwclock-set")
-
-    shell.warn("Configuring HW Clock")
-    # Comment out the three-line block guarded by the systemd-running check
-    # in /lib/udev/hwclock-set so the kernel hwclock sync runs on systemd
-    # systems too (otherwise the RTC time isn't picked up at boot). Sed
-    # range address (`/pat/,+2`) has no clean pattern_replace equivalent,
-    # so shell out to the real sed.
-    shell.run_command(
-        r"sudo sed --in-place '/if \[ -e \/run\/systemd\/system \] ; then/,+2 s/^#*/#/' /lib/udev/hwclock-set"
-    )
+    if shell.exists("/lib/udev/hwclock-set"):
+        shell.warn("Configuring HW Clock")
+        # Comment out the systemd-guarded block so the kernel hwclock sync runs.
+        shell.run_command(
+            r"sudo sed --in-place '/if \[ -e \/run\/systemd\/system \] ; then/,+2 s/^#*/#/' /lib/udev/hwclock-set"
+        )
+    else:
+        # Trixie+ util-linux dropped hwclock-set; systemd reads the kernel RTC directly.
+        print(
+            "Skipping hwclock-set configuration: /lib/udev/hwclock-set\n"
+            "not present (modern util-linux). systemd will sync the\n"
+            "system clock from the kernel RTC at boot."
+        )
 
     shell.prompt_reboot()
 


### PR DESCRIPTION
## What this changes

Follow-up to #389. Fixes the only known remaining `rtc.py` failure mode
on Trixie (Debian 13).

`rtc.py` checks for `/lib/udev/hwclock-set` and bails with
`Couldn't find /lib/udev/hwclock-set` if it isn't there. On Trixie,
`util-linux` no longer ships that script — modern systemd handles
the RTC-to-wall-clock sync directly via the kernel-bound `rtc0`
device, so there's nothing to patch.

The bail happens **after** the `config.txt` edits and the
`apt-get remove fake-hwclock` step, so on Trixie the install
**actually works** — the i2c-rtc overlay binds the chip on reboot and
systemd reads it — but the user is told the install failed.

## Fix

When `/lib/udev/hwclock-set` is absent, skip the patching step with an
informational message instead of bailing:

```python
if shell.exists("/lib/udev/hwclock-set"):
    shell.warn("Configuring HW Clock")
    shell.run_command(
        r"sudo sed --in-place '/if \[ -e \/run\/systemd\/system \] ; then/,+2 s/^#*/#/' /lib/udev/hwclock-set"
    )
else:
    print(
        "Skipping hwclock-set configuration: /lib/udev/hwclock-set\n"
        "not present (modern util-linux). systemd will sync the\n"
        "system clock from the kernel RTC at boot."
    )
```

Bookworm and earlier (which still ship `hwclock-set`) are unaffected;
they take the original path.

The `rtc.sh` original has the same bail, but I'm leaving it alone —
shell version retirement is the next step in the conversion plan.

## How I verified

Hardware-tested on test-pi5 (Raspberry Pi 5, Trixie aarch64) with an
Adafruit RGB Matrix HAT + RTC (product
[2345](https://www.adafruit.com/product/2345), DS1307). Run with
`-y` and RTC choice `1` (ds1307), starting from a stock Trixie Lite
install with I2C disabled and no pre-existing RTC overlay:

```
$ printf "1\n" | sudo python3 rtc.py -y
...
Disabling any current RTC
Adding DT overlay for ds1307
Removing fake-hwclock
RTC Package 'fake-hwclock' is not installed, so not removed
Skipping hwclock-set configuration: /lib/udev/hwclock-set
not present (modern util-linux). systemd will sync the
system clock from the kernel RTC at boot.
REBOOT NOW? [Y/n]
```

`config.txt` after the run (versus pre-run snapshot):

```diff
-#dtparam=i2c_arm=on
+dtparam=i2c_arm=on
...
+dtoverlay=i2c-rtc,ds1307
```

After reboot, the DS1307 binds correctly:

```
$ ls /dev/rtc*
/dev/rtc -> rtc0    (RP1 internal RTC, Pi 5 only)
/dev/rtc0           (RP1)
/dev/rtc1           (DS1307 ← added by overlay)

$ sudo dmesg | grep "registered as rtc"
[1.722] rpi-rtc soc@107c000000:rpi_rtc: registered as rtc0
[2.871] rtc-ds1307 1-0068: registered as rtc1

$ sudo i2cdetect -y 1 | grep '60:'
60: -- -- -- -- -- -- -- -- UU -- -- -- -- -- -- --
                            ↑
                  driver has claimed 0x68

$ sudo hwclock -w --rtc=/dev/rtc1   # write system time to DS1307
$ sudo hwclock -r --rtc=/dev/rtc1   # read back
2026-06-05 11:05:04.007793-07:00    # matches system clock ✅
```

On Pi 5 specifically: the internal RP1 RTC is `/dev/rtc0` and the
external DS1307 is `/dev/rtc1`, so `hwclock` defaults to reading RP1.
You need `--rtc=/dev/rtc1` to talk to the HAT. systemd's boot-time
RTC sync uses `rtc0` (RP1 on Pi 5; the i2c chip on older Pis where
RP1 doesn't exist), so the practical effect is what users expect:
plug in the HAT, reboot, the system clock is correct without NTP.

## Out of scope

- Surfacing `shell.bail()` exits with a non-zero exit code. Right now
  `bail()` exits `0`, so scripted callers can't detect failure. Worth
  its own upstream `adafruit_python_shell` PR.
- Retiring `rtc.sh` to `converted_shell_scripts/` once the Learn guide
  is updated to point at the Python version.
