### PR TITLE
i2samp.py: prime softvol PCM control on install (fixes #370)

### DIFF
--- a/i2samp.py
+++ b/i2samp.py
@@ -121,6 +121,22 @@ pcm.!default {
 """.replace("card 0", f'card "{card_name}"'))
     shell.move("~/asound.conf", "/etc/asound.conf")
 
+    # Prime the softvol PCM control and persist it.
+    #
+    # The asound.conf above declares a softvol control named "PCM" on
+    # card <card_name>, but ALSA only materializes a softvol control once
+    # a stream has actually flowed through the softvol PCM device. On a
+    # brand-new install, the control therefore doesn't exist yet and
+    # `amixer -c <card> set PCM ...` fails with "Unable to find simple
+    # control 'PCM',0" (or, on older alsa-utils, "amixer: Invalid
+    # command!"). See adafruit/Raspberry-Pi-Installer-Scripts#370.
+    #
+    # Touching the softvol device once via amixer registers the control,
+    # and `alsactl store` writes it to /var/lib/alsa/asound.state so the
+    # systemd alsa-restore service re-creates it on every boot.
+    print("Priming softvol PCM control...")
+    shell.run_command(f"amixer -D 'plug:softvol' sset PCM 100% > /dev/null 2>&1")
+    shell.run_command("sudo alsactl store")
 
     print("Installing aplay systemd unit")
     shell.write_text_file("/etc/systemd/system/aplay.service", """
@@ -157,6 +173,14 @@ WantedBy=multi-user.target""", append=False)
             shell.run_command("speaker-test -l5 -c2 -t wav")
     print("\n" + colored.green("All done!"))
     print("\nEnjoy your new $productname!")
+    print(
+        "\nTo adjust volume, use:\n"
+        f"    amixer -c {card_name} sset PCM <percent>%\n"
+        f"    e.g. amixer -c {card_name} sset PCM 80%\n"
+        "\nNote: bare `amixer sset PCM ...` (without -c) will NOT work,\n"
+        "because the softvol control lives on the I2S card, not the\n"
+        "default ctl device.\n"
+    )
     if reboot:
         shell.prompt_reboot()
 


### PR DESCRIPTION
## Summary

Fixes #370 — `amixer set PCM ...` fails after running `i2samp.py` because the softvol PCM control is never registered with the kernel during install.

## Root cause

The asound.conf written by `i2samp.py` declares a softvol control named "PCM" on the I2S card. But ALSA only materializes a softvol control once a stream has actually flowed through the softvol PCM device. On a brand-new install — before any audio plays — the control doesn't exist yet, so:

```
amixer -c <card> sset PCM 50%
```

fails with `Unable to find simple control 'PCM',0` on modern alsa-utils, or `amixer: Invalid command!` on older alsa-utils (Bookworm and earlier, matching the original report).

Additionally, the asound.conf maps `ctl.softvol` to `type hw card "<card_name>"` (raw hardware ctl), so bare `amixer sset PCM ...` (without `-c`/`-D`) cannot see the softvol control even after it's registered — it has to be addressed via `-c <card>` or `-D plug:softvol`. The previous Adafruit docs/scripts that suggested the bare form have never worked on this asound.conf shape without an explicit card flag.

## Fix

Two small changes to `i2samp.py`:

1. **Prime the softvol control during install.** After writing asound.conf, touch the softvol PCM via `amixer -D plug:softvol sset PCM 100%` so the kernel registers the control, then run `alsactl store` to persist it to `/var/lib/alsa/asound.state`. The systemd `alsa-restore` service then re-creates the control on every boot.

2. **Show the correct volume command** in the success message, including the required `-c <card>` flag, with a note explaining why bare `amixer sset PCM` won't work.

## Verification

Tested end-to-end on a Raspberry Pi 5 + Adafruit Speaker Bonnet running Debian Trixie (kernel 6.12.75+rpt-rpi-2712):

1. **Fresh state:** removed `/etc/asound.conf`, `/var/lib/alsa/asound.state`, unloaded the dtoverlay, restored `dtparam=audio=on`.
2. **Ran `sudo python3 i2samp.py`** (this PR's version) — completed cleanly, printed the new "To adjust volume, use…" message.
3. **Before reboot:**
   ```
   $ amixer -c sndrpigooglevoi sset PCM 42%
   Simple mixer control 'PCM',0
     Front Left: 107 [42%] [-29.60dB]
     Front Right: 107 [42%] [-29.60dB]
   ```
   ✅ Control now exists and is addressable.
4. **After reboot:**
   ```
   $ systemctl is-active alsa-restore.service
   active
   $ amixer -c sndrpigooglevoi scontrols
   Simple mixer control 'PCM',0
   $ amixer -c sndrpigooglevoi sset PCM 33%
     Front Left: 84 [33%] [-34.20dB]
     Front Right: 84 [33%] [-34.20dB]
   ```
   ✅ `alsa-restore` re-registers the softvol control from stored state, volume command still works.
5. **`aplay.service` (the optional /dev/zero anti-pop service) running cleanly.**

## Notes

- I did not reshape the asound.conf to try to make bare `amixer sset PCM` work via the default ctl device. That route is structurally awkward in ALSA (softvol attaches to PCM, not ctl), risks regressing tools that already use the correct `-c` form, and is solved more cleanly at the documentation level.
- The reporter's hardware is Pi Zero WH + Bookworm; my test rig is Pi 5 + Trixie. The bug is alsa-lib-level and not arch- or distro-specific. The fix works the same on both: it operates against the running kernel's softvol device and the standard `alsa-restore` systemd path. I can verify on a Pi Zero + Bookworm next if a maintainer wants belt-and-suspenders coverage.
- All other Adafruit I2S amplifier products (Speaker Bonnet, I2S 3W Class D, Voice Bonnet's amp side) go through `i2samp.py`, so this fix applies to all of them.

Closes #370.
