### PR TITLE
pi-eyes: fix Pi 5 SPI1 right-eye display (fixes #295)

### DIFF
--- a/overlays/spi1-rp1-eyes-overlay.dts
+++ b/overlays/spi1-rp1-eyes-overlay.dts
@@ -1,0 +1,55 @@
+/dts-v1/;
+/plugin/;
+
+/*
+ * spi1-rp1-eyes: fix SPI1 data-pin muxing on Raspberry Pi 5 (RP1)
+ * for the Adafruit Animated Snake Eyes Bonnet.
+ *
+ * Background
+ * ----------
+ * On Pi 3B / Pi 4 (BCM283x), the stock `spi1-3cs` overlay correctly
+ * mux GPIO19 / GPIO20 / GPIO21 to the SPI1 controller as MISO / MOSI
+ * / SCLK using the legacy `brcm,pins` / `brcm,function` pinctrl
+ * format.
+ *
+ * On Pi 5 (RP1), that legacy pinctrl format is silently ignored by
+ * the RP1 pinctrl driver. The result is that `spi1-3cs` brings up
+ * the SPI1 chip-selects (CE0/CE1/CE2 on GPIO18/17/16, which are
+ * plain GPIOs) but never muxes the MOSI / SCLK data pins, so the
+ * right-eye TFT receives a clocking CS but no usable data and the
+ * panel stays permanently black.
+ *
+ * Fix
+ * ---
+ * The Pi 5 base device tree already contains a correct RP1-native
+ * pinctrl node for SPI1 (`rp1_spi1_gpio19`, function = "spi1",
+ * pins = "gpio19", "gpio20", "gpio21"). This overlay simply
+ * re-points the SPI1 controller's `pinctrl-0` at that node,
+ * replacing `spi1-3cs`'s broken legacy entry.
+ *
+ * Apply order in /boot/firmware/config.txt — this overlay MUST be
+ * loaded AFTER `spi1-3cs`, so that its `pinctrl-0` assignment wins:
+ *
+ *     dtparam=spi1=on
+ *     dtoverlay=spi1-3cs
+ *     dtoverlay=spi1-rp1-eyes
+ *
+ * Safe to load on Pi 3B / Pi 4 as well: the `rp1_spi1_gpio19` label
+ * is only present in the RP1/Pi-5 DTB, so dtoverlay will simply
+ * skip this overlay's fixup on older Pis where the legacy
+ * `spi1-3cs` pinctrl already works correctly.
+ *
+ * Issue: https://github.com/adafruit/Raspberry-Pi-Installer-Scripts/issues/295
+ */
+
+/ {
+	compatible = "brcm,bcm2712";
+
+	fragment@0 {
+		target = <&spi1>;
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&rp1_spi1_gpio19>;
+		};
+	};
+};

--- a/pi-eyes.sh
+++ b/pi-eyes.sh
@@ -15,6 +15,10 @@
 #   - Uses xinit to launch eyes.py (pi3d requires EGL; dispmanx is gone)
 #   - Uses rpi-lgpio on Pi 5 (RP1 GPIO controller, RPi.GPIO not supported)
 #   - Autostart via systemd units (rc.local is deprecated in Trixie)
+#   - On Pi 5, installs spi1-rp1-eyes overlay to fix SPI1 data-pin
+#     muxing (the stock spi1-3cs overlay uses legacy brcm,pins format
+#     that the RP1 pinctrl driver ignores, so the right-eye TFT stays
+#     black until this overlay re-points SPI1 at rp1_spi1_gpio19)
 
 if [ $(id -u) -ne 0 ]; then
     echo "Installer must be run as root."
@@ -144,6 +148,7 @@ apt-get install -y \
     build-essential \
     python3-venv python3-dev python3-full \
     libx11-dev libxext-dev \
+    device-tree-compiler \
     git curl unzip
 
 # Python GPIO library: Pi 5 uses the RP1 controller; RPi.GPIO does not
@@ -277,8 +282,35 @@ fi
 if [ $SCREEN_SELECT -ne 4 ]; then
     raspi-config nonint do_spi 0
     reconfig  "$CONFIG_TXT"  "^.*dtparam=spi1.*$"   "dtparam=spi1=on"
-    reconfig  "$CONFIG_TXT"  "^.*dtoverlay=spi1.*$"  "dtoverlay=spi1-3cs"
+    # Match the spi1-3cs line specifically so we don't clobber the
+    # spi1-rp1-eyes overlay line we may also need on Pi 5.
+    reconfig  "$CONFIG_TXT"  "^.*dtoverlay=spi1-3cs.*$"  "dtoverlay=spi1-3cs"
     reconfig2 "$CMDLINE_TXT" "spidev\.bufsiz=[^ ]*"  "spidev.bufsiz=8192"
+
+    # On Pi 5, the stock spi1-3cs overlay's data-pin pinctrl is in the
+    # legacy brcm,pins format which the RP1 driver ignores. Without an
+    # additional overlay, GPIO19/20/21 never get muxed to SPI1, so the
+    # right-eye TFT receives clocking CS but no usable data and stays
+    # black. spi1-rp1-eyes re-points the SPI1 controller's pinctrl-0
+    # at the base DTB's correct rp1_spi1_gpio19 node. See issue #295.
+    if [ $IS_PI5 -eq 1 ]; then
+        SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+        SPI1_DTS="${SCRIPT_DIR}/overlays/spi1-rp1-eyes-overlay.dts"
+        SPI1_DTBO="/boot/firmware/overlays/spi1-rp1-eyes.dtbo"
+        if [ -f "$SPI1_DTS" ]; then
+            echo "Pi 5: compiling spi1-rp1-eyes overlay (fixes SPI1 data-pin muxing)..."
+            dtc --warning no-unit_address_vs_reg -I dts -O dtb \
+                -o "$SPI1_DTBO" "$SPI1_DTS"
+            # Append spi1-rp1-eyes line if not already present. Must
+            # come AFTER spi1-3cs so its pinctrl-0 assignment wins.
+            if ! grep -q "^dtoverlay=spi1-rp1-eyes" "$CONFIG_TXT"; then
+                echo "dtoverlay=spi1-rp1-eyes" >> "$CONFIG_TXT"
+            fi
+        else
+            echo "WARNING: ${SPI1_DTS} not found."
+            echo "The right-eye display will not work on Pi 5 without it."
+        fi
+    fi
 fi
 
 # USB Ethernet gadget (Pi Zero)


### PR DESCRIPTION
## Problem

On Raspberry Pi 5, the Adafruit Animated Snake Eyes Bonnet only ever
lights up the **left** eye. The right eye (driven via SPI1) stays
permanently black even though the backlight is on, the panel is
healthy, and the spidev nodes (`/dev/spidev1.0`/`.1`/`.2`) all
appear under `/dev`.

## Root cause

The stock `spi1-3cs` overlay (in `raspberrypi/firmware`) declares
its data-pin pinmux using the legacy `brcm,pins` / `brcm,function`
format from the BCM283x era. The **RP1 pinctrl driver on the Pi 5
silently ignores that format** — there is no warning in dmesg, the
overlay loads, and the spidev nodes appear, but `GPIO19` / `GPIO20`
/ `GPIO21` are never actually muxed to the SPI1 controller.

The SPI1 chip-selects on `GPIO16` / `GPIO17` / `GPIO18` still
work because they're plain GPIOs, so software-side `spidev` writes
appear to succeed and CS pulses correctly, but the panel receives no
usable MOSI/SCLK data — hence the dead-black display.

You can confirm this state with `pinctrl-mux`:

```
# Without the fix
pin 19 (gpio19): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 20 (gpio20): pwr_button     (GPIO UNCLAIMED)
pin 21 (gpio21): (MUX UNCLAIMED) (GPIO UNCLAIMED)

# With the fix
pin 19 (gpio19): 1f00054000.spi function spi1 group gpio19
pin 20 (gpio20): 1f00054000.spi function spi1 group gpio20
pin 21 (gpio21): 1f00054000.spi function spi1 group gpio21
```

## Fix

The Pi 5 base device tree already contains a correct RP1-native pin
group for SPI1:

```
rp1_spi1_gpio19 {
    function = "spi1";
    pins = "gpio19", "gpio20", "gpio21";
    drive-strength = <0x0c>;
    bias-disable;
    slew-rate = <0x01>;
};
```

This PR adds a small overlay (`overlays/spi1-rp1-eyes-overlay.dts`)
that re-points the SPI1 controller's `pinctrl-0` at that node, and
teaches `pi-eyes.sh` to compile and enable it on Pi 5.

Apply order in `/boot/firmware/config.txt` — `spi1-rp1-eyes` MUST
load **after** `spi1-3cs` so its `pinctrl-0` assignment wins:

```
dtparam=spi1=on
dtoverlay=spi1-3cs
dtoverlay=spi1-rp1-eyes
```

## Changes

- **New:** `overlays/spi1-rp1-eyes-overlay.dts` — 8-line overlay,
  compiles to a ~360-byte `.dtbo` with a single phandle fixup for
  `rp1_spi1_gpio19`. Safe to load on Pi 3B/Pi 4 too: the fixup
  symbol only exists in the RP1/Pi-5 DTB, so `dtoverlay` simply
  skips the apply on older Pis where `spi1-3cs` already works.
- **`pi-eyes.sh`:**
  - Installs `device-tree-compiler` (for `dtc`).
  - On Pi 5, compiles the new overlay to
    `/boot/firmware/overlays/spi1-rp1-eyes.dtbo` and appends
    `dtoverlay=spi1-rp1-eyes` to `config.txt` after `spi1-3cs`.
  - Tightens the existing `spi1-3cs` reconfig regex from
    `^.*dtoverlay=spi1.*$` to `^.*dtoverlay=spi1-3cs.*$` so it
    doesn't clobber the new `dtoverlay=spi1-rp1-eyes` line on
    subsequent runs.

## Testing

Verified on Raspberry Pi 5 + Raspberry Pi OS Trixie + Adafruit
Snake Eyes Bonnet with two 1.54" ST7789 240×240 IPS displays:

- Before the overlay: right eye permanently black, left eye works
  normally. `pinctrl-mux` shows GPIO19/20/21 as
  `(MUX UNCLAIMED)`.
- After the overlay: both eyes light on a solid-color SPI fill test
  via `/dev/spidev0.0` (left) and `/dev/spidev1.2` (right).
  `pinctrl-mux` shows all three pins claimed by
  `1f00054000.spi function spi1`.
- End-to-end with the installed `pi-eyes.sh`, `xinit eyes.py` +
  `fbx2 -i` services run cleanly and both eyes animate.

Fixes #295 (and supersedes the older Pi-5 Pi-Eyes thread at #226,
which has the same root cause).

🤖 Generated with [OpenClaw](https://openclaw.ai) (Piclaw + Claude
Opus 4)