### PR TITLE
Add SPDX license headers and CI check

### DIFF
--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2026 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+name: SPDX
+
+on: [pull_request, push]
+
+jobs:
+  spdx:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-python@v6
+      with:
+        python-version: "3.x"
+    - name: Checkout Current Repo
+      uses: actions/checkout@v6
+
+    - name: check SPDX licensing
+      run: python ./SPDX.py

--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -10,11 +10,11 @@ jobs:
   spdx:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v6
-      with:
-        python-version: "3.x"
-    - name: Checkout Current Repo
-      uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - name: Checkout Current Repo
+        uses: actions/checkout@v6
 
-    - name: check SPDX licensing
-      run: python ./SPDX.py
+      - name: check SPDX licensing
+        run: python ./SPDX.py

--- a/LICENSES/GPL-2.0+.txt
+++ b/LICENSES/GPL-2.0+.txt
@@ -1,0 +1,117 @@
+GNU GENERAL PUBLIC LICENSE
+Version 2, June 1991
+
+Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public License is intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users. This General Public License applies to most of the Free Software Foundation's software and to any other program whose authors commit to using it. (Some other Free Software Foundation software is covered by the GNU Lesser General Public License instead.) You can apply it to your programs, too.
+
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs; and that you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to deny you these rights or to ask you to surrender the rights. These restrictions translate to certain responsibilities for you if you distribute copies of the software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether gratis or for a fee, you must give the recipients all the rights that you have. You must make sure that they, too, receive or can get the source code. And you must show them these terms so they know their rights.
+
+We protect your rights with two steps: (1) copyright the software, and (2) offer you this license which gives you legal permission to copy, distribute and/or modify the software.
+
+Also, for each author's protection and ours, we want to make certain that everyone understands that there is no warranty for this free software. If the software is modified by someone else and passed on, we want its recipients to know that what they have is not the original, so that any problems introduced by others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents. We wish to avoid the danger that redistributors of a free program will individually obtain patent licenses, in effect making the program proprietary. To prevent this, we have made it clear that any patent must be licensed for everyone's free use or not licensed at all.
+
+The precise terms and conditions for copying, distribution and modification follow.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License applies to any program or other work which contains a notice placed by the copyright holder saying it may be distributed under the terms of this General Public License. The "Program", below, refers to any such program or work, and a "work based on the Program" means either the Program or any derivative work under copyright law: that is to say, a work containing the Program or a portion of it, either verbatim or with modifications and/or translated into another language. (Hereinafter, translation is included without limitation in the term "modification".) Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running the Program is not restricted, and the output from the Program is covered only if its contents constitute a work based on the Program (independent of having been made by running the Program). Whether that is true depends on what the Program does.
+
+1. You may copy and distribute verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and give any other recipients of the Program a copy of this License along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Program or any portion of it, thus forming a work based on the Program, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
+
+     a) You must cause the modified files to carry prominent notices stating that you changed the files and the date of any change.
+
+     b) You must cause any work that you distribute or publish, that in whole or in part contains or is derived from the Program or any part thereof, to be licensed as a whole at no charge to all third parties under the terms of this License.
+
+     c) If the modified program normally reads commands interactively when run, you must cause it, when started running for such interactive use in the most ordinary way, to print or display an announcement including an appropriate copyright notice and a notice that there is no warranty (or else, saying that you provide a warranty) and that users may redistribute the program under these conditions, and telling the user how to view a copy of this License. (Exception: if the Program itself is interactive but does not normally print such an announcement, your work based on the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Program, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Program, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program with the Program (or with a work based on the Program) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+
+3. You may copy and distribute the Program (or a work based on it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you also do one of the following:
+
+     a) Accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange; or,
+
+     b) Accompany it with a written offer, valid for at least three years, to give any third party, for a charge no more than your cost of physically performing source distribution, a complete machine-readable copy of the corresponding source code, to be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange; or,
+
+     c) Accompany it with the information you received as to the offer to distribute corresponding source code. (This alternative is allowed only for noncommercial distribution and only if you received the program in object code or executable form with such an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for making modifications to it. For an executable work, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the executable. However, as a special exception, the source code distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
+
+If distribution of executable or object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place counts as distribution of the source code, even though third parties are not compelled to copy the source along with the object code.
+
+4. You may not copy, modify, sublicense, or distribute the Program except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense or distribute the Program is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
+
+5. You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Program or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Program (or any work based on the Program), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Program or works based on it.
+
+6. Each time you redistribute the Program (or any work based on the Program), the recipient automatically receives a license from the original licensor to copy, distribute or modify the Program subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties to this License.
+
+7. If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Program at all. For example, if a patent license would not permit royalty-free redistribution of the Program by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system, which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
+
+This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+
+8. If the distribution and/or use of the Program is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Program under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+
+9. The Free Software Foundation may publish revised and/or new versions of the General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Program specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of this License, you may choose any version ever published by the Free Software Foundation.
+
+10. If you wish to incorporate parts of the Program into other free programs whose distribution conditions are different, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+
+NO WARRANTY
+
+11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+     one line to give the program's name and an idea of what it does. Copyright (C) yyyy name of author
+
+     This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
+
+     This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+     You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA. Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this when it starts in an interactive mode:
+
+     Gnomovision version 69, Copyright (C) year name of author Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'. This is free software, and you are welcome to redistribute it under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate parts of the General Public License. Of course, the commands you use may be called something other than `show w' and `show c'; they could even be mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your school, if any, to sign a "copyright disclaimer" for the program, if necessary. Here is a sample; alter the names:
+
+     Yoyodyne, Inc., hereby disclaims all copyright interest in the program `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+signature of Ty Coon, 1 April 1989 Ty Coon, President of Vice

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/SPDX.py
+++ b/SPDX.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: 2022 Eva Herrada for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+import os
+import subprocess
+import sys
+
+print("Starting SPDX Check")
+
+BUILD_DIR = ""
+try:
+    # If we're on actions
+    BUILD_DIR = os.environ["GITHUB_WORKSPACE"]
+except KeyError:
+    try:
+        # If we're on travis
+        BUILD_DIR = os.environ["TRAVIS_BUILD_DIR"]
+    except KeyError:
+        # If we're running on local machine
+        BUILD_DIR = os.path.abspath(".")
+
+print(f"Running in {BUILD_DIR}\n")
+files = []
+missing_file = []
+
+fail = False
+
+# Extensions to check for SPDX headers.
+EXTENSIONS = ("py", "cpp", "ino", "h", "c", "sh")
+
+# Directories to skip while walking the tree.
+SKIP_DIRS = (".git", "LICENSES")
+
+
+def compare(file_, line_, correct):
+    old = line_[:-1]
+    try:
+        right = line_.split(":")[1][:-1]
+    except IndexError:
+        print(f"{file_} may have an SPDX format issue:")
+        print("The following line:")
+        print(old)
+        print("May be missing a colon.\nIt should look like this:")
+        print(correct, "\n")
+        return True
+
+    new = f"{correct}{right.strip()}"
+    cmd = f'CMD="diff <(echo \\"{old}\\") <(echo \\"{new}\\")"; /bin/bash -c "$CMD"'
+    output = subprocess.getoutput(cmd).split("\n")
+
+    if output:
+        print(f"{file_} may have an SPDX format issue:")
+        print("Change this:")
+        print(output[1][2:])
+        print("To this:")
+        print(output[3][2:], "\n")
+        return True
+
+    return False
+
+
+for r, d, f in os.walk(BUILD_DIR):
+    d[:] = [sub for sub in d if sub not in SKIP_DIRS]
+    for file in f:
+        if file.split(".")[-1] in EXTENSIONS:
+            files.append(os.path.join(r, file))
+
+for file in files:
+    with open(file, "r") as F:
+        lines = []
+        for line in F.readlines():
+            if line[0] != "#" and line[:2] != "//":
+                break
+            lines.append(line)
+        status = {"copyright": False, "license": False, "licensefile": False}
+        license_name = None
+        for line in lines:
+            if "SPDX-FileCopyrightText" in line:
+                status["copyright"] = True
+                if (
+                    "# SPDX-FileCopyrightText: " not in line
+                    and "// SPDX-FileCopyrightText: " not in line
+                ):
+                    prefix = (
+                        "# SPDX-FileCopyrightText: "
+                        if file.endswith(".py") or file.endswith(".sh")
+                        else "// SPDX-FileCopyrightText: "
+                    )
+                    if compare(file, line, prefix):
+                        fail = True
+
+            if "SPDX-License-Identifier" in line:
+                failed = False
+                if (
+                    "# SPDX-License-Identifier: " not in line
+                    and "// SPDX-License-Identifier: " not in line
+                ):
+                    prefix = (
+                        "# SPDX-License-Identifier: "
+                        if file.endswith(".py") or file.endswith(".sh")
+                        else "// SPDX-License-Identifier: "
+                    )
+                    if compare(file, line, prefix):
+                        fail = True
+                        failed = True
+                if not failed:
+                    license_name = line.split("SPDX-License-Identifier: ")[1].strip()
+                    status["license"] = True
+                    if os.path.isfile(BUILD_DIR + f"/LICENSES/{license_name}.txt"):
+                        status["licensefile"] = True
+                    elif f"LICENSES/{license_name}.txt" not in missing_file:
+                        missing_file.append(f"LICENSES/{license_name}.txt")
+
+        if not all(status.values()):
+            fail = True
+            print(f"{file} is missing SPDX\n")
+            continue
+        if not status["copyright"]:
+            fail = True
+            print(f"{file}: SPDX-FileCopyrightText line is missing")
+        if not status["license"]:
+            fail = True
+            print(f"{file}: SPDX-License-Identifier line is missing")
+        if not status["licensefile"] and status["license"]:
+            fail = True
+            print(f"{file}: {license_name}.txt is missing from LICENSES/")
+        if (
+            not status["copyright"]
+            or not status["license"]
+            or not status["licensefile"]
+        ):
+            print("\n")
+
+if fail:
+    if missing_file:
+        print("Missing files:", missing_file)
+    sys.exit(-1)
+sys.exit(0)

--- a/adafruit-pitft.py
+++ b/adafruit-pitft.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 """
 Adafruit PiTFT Installer Script
 (C) Adafruit Industries, Creative Commons 3.0 - Attribution Share Alike

--- a/adafruit_fanservice.py
+++ b/adafruit_fanservice.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 """
 Adafruit Raspberry Pi Fan Service Setup Script
 (C) Adafruit Industries, Creative Commons 3.0 - Attribution Share Alike

--- a/ar1100.py
+++ b/ar1100.py
@@ -1,4 +1,8 @@
 #!/usr/bin/python
+# SPDX-FileCopyrightText: 2024 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 import usb.core
 import usb.util
 import time

--- a/arcade-bonnet.py
+++ b/arcade-bonnet.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 """
 Adafruit Raspberry Pi Arcade Bonnet Setup Script
 (C) Adafruit Industries, Creative Commons 3.0 - Attribution Share Alike

--- a/arcade-bonnet.sh
+++ b/arcade-bonnet.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2017 Phillip Burgess for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 
 if [ $(id -u) -ne 0 ]; then
 	echo "Installer must be run as root."

--- a/converted_shell_scripts/adafruit-pitft.sh
+++ b/converted_shell_scripts/adafruit-pitft.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2018 Limor "Ladyada" Fried for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 # (C) Adafruit Industries, Creative Commons 3.0 - Attribution Share Alike
 #
 # Instructions!

--- a/converted_shell_scripts/adafruit_fanservice.sh
+++ b/converted_shell_scripts/adafruit_fanservice.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2020 lady ada for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 
 if [ $(id -u) -ne 0 ]; then
 	echo "Installer must be run as root."

--- a/converted_shell_scripts/i2samp.sh
+++ b/converted_shell_scripts/i2samp.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2016 ladyada for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 
 : <<'DISCLAIMER'
 

--- a/converted_shell_scripts/i2smic.sh
+++ b/converted_shell_scripts/i2smic.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2020 caternuson for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 #-------------------------------------------------------------------------
 # Installer script for I2S microphone support on Raspberry Pi
 #

--- a/converted_shell_scripts/joy-bonnet.sh
+++ b/converted_shell_scripts/joy-bonnet.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2017 Phillip Burgess for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 
 if [ $(id -u) -ne 0 ]; then
 	echo "Installer must be run as root."

--- a/converted_shell_scripts/libgpiod.sh
+++ b/converted_shell_scripts/libgpiod.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+# SPDX-FileCopyrightText: 2018 Brennen Bearnes for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 
 # Instructions!
 # cd ~

--- a/converted_shell_scripts/pi-touch-cam.sh
+++ b/converted_shell_scripts/pi-touch-cam.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2016 Phillip Burgess for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 
 if [ $(id -u) -ne 0 ]; then
 	echo "Installer must be run as root."

--- a/converted_shell_scripts/pitft-fbcp.sh
+++ b/converted_shell_scripts/pitft-fbcp.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2016 Phillip Burgess for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 
 if [ $(id -u) -ne 0 ]; then
 	echo "Installer must be run as root."

--- a/converted_shell_scripts/rpi-pin-kernel-firmware.sh
+++ b/converted_shell_scripts/rpi-pin-kernel-firmware.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 # rpi-pin-kernel-firmware: Pin a specific version of the rpi kernel and firmware
 
 set -e

--- a/i2c.sh
+++ b/i2c.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2016 ladyada for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 
 : <<'DISCLAIMER'
 

--- a/i2samp.py
+++ b/i2samp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 import os
 import subprocess
 

--- a/install_wm8960.sh
+++ b/install_wm8960.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 
 set -o xtrace
 set -o errexit

--- a/joy-bonnet.py
+++ b/joy-bonnet.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 """
 Adafruit Raspberry Pi Joy Bonnet Setup Script
 (C) Adafruit Industries, Creative Commons 3.0 - Attribution Share Alike

--- a/libgpiod.py
+++ b/libgpiod.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 # Instructions!
 # cd ~
 # sudo apt-get install python3-pip

--- a/old_scripts/adafruit-pitft-mipi.py
+++ b/old_scripts/adafruit-pitft-mipi.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 """
 Adafruit PiTFT MIPI Display Installer Script
 (C) Adafruit Industries, Creative Commons 3.0 - Attribution Share Alike

--- a/pi-eyes.sh
+++ b/pi-eyes.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2016 Phillip Burgess for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 # Adafruit Snake Eyes Bonnet installer for Raspberry Pi OS Trixie (Debian 13).
 # Supports Pi 3B, Pi 4, and Pi 5.
 #

--- a/pi-touch-cam.py
+++ b/pi-touch-cam.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 """
 Adafruit Pi Touch Cam Setup Script
 (C) Adafruit Industries, Creative Commons 3.0 - Attribution Share Alike

--- a/pitft-fbcp.py
+++ b/pitft-fbcp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 import os
 
 try:

--- a/raspi-blinka.py
+++ b/raspi-blinka.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 """
 Adafruit Raspberry Pi Blinka Setup Script
 (C) Adafruit Industries, Creative Commons 3.0 - Attribution Share Alike

--- a/raspi-spi-reassign.py
+++ b/raspi-spi-reassign.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 """
 Adafruit Raspberry Pi SPI Chip Enable Reassignment Script
 (C) Adafruit Industries, Creative Commons 3.0 - Attribution Share Alike

--- a/read-only-fs.sh
+++ b/read-only-fs.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2017 Phillip Burgess for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 
 echo "NEWS: see https://learn.adafruit.com/read-only-raspberry-pi"
 echo "This script is deprecated, with better functionality now in"

--- a/retrogame.sh
+++ b/retrogame.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2016 Phillip Burgess for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 
 if [ $(id -u) -ne 0 ]; then
 	echo "Installer must be run as root."

--- a/rgb-matrix.sh
+++ b/rgb-matrix.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2018 Phillip Burgess for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 
 # INSTALLER SCRIPT FOR ADAFRUIT RGB MATRIX BONNET OR HAT
 

--- a/rpi_pin_kernel_firmware.py
+++ b/rpi_pin_kernel_firmware.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 """
 Adafruit Raspberry Pi Script to Pin a specific version of the rpi kernel and firmware
 (C) Adafruit Industries, Creative Commons 3.0 - Attribution Share Alike

--- a/rtc.sh
+++ b/rtc.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2016 ladyada for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 
 : <<'DISCLAIMER'
 

--- a/spectro.sh
+++ b/spectro.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2019 Phillip Burgess for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 
 # INSTALLER SCRIPT FOR ADAFRUIT SPECTRO PROJECT
 

--- a/st7789_module/fb_st7789v.c
+++ b/st7789_module/fb_st7789v.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0+
+// SPDX-FileCopyrightText: 2015 Dennis Menschel
 /*
  * FB driver for the ST7789V LCD Controller
  *

--- a/st7789_module/fbtft.h
+++ b/st7789_module/fbtft.h
@@ -1,4 +1,5 @@
-/* SPDX-License-Identifier: GPL-2.0+ */
+// SPDX-License-Identifier: GPL-2.0+
+// SPDX-FileCopyrightText: 2013 Noralf Tronnes
 /* Copyright (C) 2013 Noralf Tronnes */
 
 #ifndef __LINUX_FBTFT_H

--- a/st7789_module/reload.sh
+++ b/st7789_module/reload.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2023 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 
 # Unload
 sudo dtoverlay -r drm-minipitft114

--- a/templates/con2fbmap-helper.sh
+++ b/templates/con2fbmap-helper.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2025 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 
 # Map the Linux console (tty1) to the SPI TFT framebuffer.
 #

--- a/voice_bonnet.sh
+++ b/voice_bonnet.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: 2016 ladyada for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
 
 : <<'DISCLAIMER'
 


### PR DESCRIPTION
Closes #244.

Adds an automatic SPDX/license header check (like the one on the Learn repo) plus the headers needed for it to pass.

## What this does
- **Backfills SPDX headers** on every source file (`.py`/`.sh`/`.c`/`.h`) that was missing them — `SPDX-FileCopyrightText` + `SPDX-License-Identifier`.
- **Adds `LICENSES/`** with `MIT.txt` and `GPL-2.0+.txt`.
- **Adds `SPDX.py`** (adapted from the Learn repo's checker, extended to also check `.sh` files and to skip `LICENSES/` and `.git/`).
- **Adds `.github/workflows/spdx.yml`** to run the check on `pull_request` and `push`.

## Licensing decisions
- Everything is **MIT** except the two upstream kernel-derived files in `st7789_module/` (`fb_st7789v.c`, `fbtft.h`), which keep their original **GPL-2.0+** and original authors (Dennis Menschel, Noralf Tronnes).
- Files that previously carried the legacy "Creative Commons 3.0 - Attribution Share Alike" prose were set to **MIT**, since that CC license is a content/docs license rather than a code license and MIT reflects the intended licensing for these scripts. `adafruit-pitft.py` is included here (rewritten from scratch).
- Copyright years and authors come from each file's first commit in git history. Author names are left in the form the original authors use (e.g. `ladyada`, `caternuson`).

## Verification
`python ./SPDX.py` passes locally (exit 0) across the whole tree after these changes, so CI should be green on this PR.