### PR TITLE
Convert i2c.sh to Python

### DIFF
--- a/i2c.py
+++ b/i2c.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2016 ladyada for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+# INSTALLER SCRIPT TO ENABLE I2C ON A RASPBERRY PI
+
+try:
+    from adafruit_shell import Shell
+except ImportError:
+    raise RuntimeError(
+        "The library 'adafruit_shell' was not found. To install, try typing: "
+        "sudo pip3 install adafruit-python-shell"
+    )
+
+shell = Shell()
+shell.group = "I2C"
+
+
+def main():
+    shell.clear()
+    print("This script will enable I2C on your Raspberry Pi")
+    print("")
+    shell.warn("--- Warning ---")
+    print("Always be careful when running scripts and commands copied")
+    print("from the internet. Ensure they are from a trusted source.")
+    print("")
+
+    if not shell.prompt("Do you wish to continue?", default="n"):
+        shell.bail("Aborting...")
+
+    print("")
+    print("Enabling I2C...")
+    # raspi-config performs the device-tree (dtparam=i2c_arm=on) edit and
+    # loads the i2c kernel module on the current Raspberry Pi OS.
+    shell.run_raspi_config("do_i2c 0")
+
+    # Ensure the i2c-dev character interface is loaded at boot so /dev/i2c-*
+    # is available to user-space tools (i2cdetect, Blinka, etc.).
+    shell.append_if_missing("/etc/modules", "i2c-dev")
+    shell.run_command("modprobe i2c-dev")
+
+    print("")
+    shell.info("Enabled")
+    print("")
+    print("Settings take effect on next boot.")
+    print("")
+    shell.prompt_reboot()
+
+
+if __name__ == "__main__":
+    shell.require_root()
+    main()


### PR DESCRIPTION
Converts `i2c.sh` to `i2c.py`, modernized for current Raspberry Pi OS.

## What changed

The original 363-line script was the Pimoroni installer template, but its actual job is small: **enable I2C**. Most of it was scaffolding that no longer applies to current Pi OS:

- Wheezy/Jessie/Squeeze release checks
- armv6/armhf-only gating
- the "no Device Tree" branch
- the legacy `i2c-bcm2708` module name and `raspi-blacklist.conf` handling

Following the repo's modernization approach for these conversions, `i2c.py` does the modern equivalent:

- `shell.run_raspi_config("do_i2c 0")` — raspi-config performs the `dtparam=i2c_arm=on` device-tree edit and loads the kernel module (same pattern as `arcade-bonnet.py`, `joy-bonnet.py`, `raspi-blinka.py`).
- `shell.append_if_missing("/etc/modules", "i2c-dev")` + `modprobe i2c-dev` — ensures the `i2c-dev` character interface is available at boot so `/dev/i2c-*` exists for i2cdetect / Blinka / user tools.
- Keeps the original "trusted source" warning and continue prompt.

Uses `append_if_missing`, which is in `adafruit-python-shell >= 1.14.0`.

## Testing

Hardware-tested on a Raspberry Pi 5 (Trixie):

- Started from a **disabled** I2C state (`dtparam=i2c_arm=off`, `i2c-dev` removed from `/etc/modules`, `get_i2c` = 1).
- Ran the script → `dtparam=i2c_arm=on`, `i2c-dev` back in `/etc/modules`, `get_i2c` = 0, `i2c_dev` module loaded live.
- **Idempotent:** a second run did not duplicate the `/etc/modules` entry.
- Rig reverted to baseline after testing.

`ruff format` + `ruff check` clean.
